### PR TITLE
Next step

### DIFF
--- a/CosmicTrigger/include/CommonDef.cpp
+++ b/CosmicTrigger/include/CommonDef.cpp
@@ -1,17 +1,22 @@
 #include "CommonDef.h"
 
-
-
-bool TestError(int erreur,string endroit, bool fatal){
-  if(!erreur==0){
-    if (fatal) cerr<<"***FATAL ";
-    cerr<<"ERROR, code "<<erreur;
-    if(!(endroit=="")) cerr<<" @ "<<endroit<<endl;
-    else cerr<<endl;
-    if (fatal) exit(-1);
-    return(0);
+bool TestError(int error, std::string where, bool fatal) {
+  if (error) {
+    if (fatal)
+        std::cerr << "***FATAL ";
+    std::cerr << "ERROR, code " << error;
+    
+    if (where != "")
+        std::cerr << " @ "<< where << std::endl;
+    else std::cerr << std::endl;
+    
+    if (fatal)
+        exit(-1);
+    
+    return 0;
   }
-  else return(1);
+  
+  else return 1;
 }
 
 string show_hex(int number, int size){

--- a/CosmicTrigger/include/CommonDef.h
+++ b/CosmicTrigger/include/CommonDef.h
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-bool TestError(int erreur,string endroit="",bool fatal=false);
+bool TestError(int error, std::string where="", bool fatal = false);
 /**<
  * \brief Handles errors.
  * 

--- a/CosmicTrigger/include/HV.cpp
+++ b/CosmicTrigger/include/HV.cpp
@@ -28,26 +28,43 @@ int hv::getStatus(){
     else return(-1);
 }
 
-int hv::comLoop(int data1, int data2){
+int hv::comLoop(int data1, int data2) {
+    // FIXME
     usleep(100000);
-    if(getStatus()==0xFFFF&&vLevel(WARNING))cout<<"*  WARNING: Initial status of HV was: error..."<<endl;
-    int DATA=0x0001;
-    if(!TestError(writeData(this->add,&DATA),"HV: comLoop, starting communication")){return(-1);}  //Hello  
-    DATA=this->hvAdd;
-    if(!TestError(writeData(this->add,&DATA),"HV: comLoop, setting alim address")){return(-1);}   //Alim add
+    
+    if (getStatus() == 0xFFFF && vLevel(WARNING))
+        std::cout << "*  WARNING: Initial status of HV was: error..." << std::endl;
+    
+    int DATA = 0x0001;
+    
+    if (!TestError(writeData(add, &DATA), "HV: comLoop, starting communication"))
+        return -1;  //Hello
+    
+    DATA = hvAdd;
+    
+    if(!TestError(writeData(add, &DATA), "HV: comLoop, setting alim address"))
+        return -1;   //Alim address
 
-    DATA=data1;
-    if(!TestError(writeData(this->add,&DATA),"HV: comLoop, setting first command")){return(-1);}   //Command
-    if (data2>-1){
-      DATA=data2;
-      if(!TestError(writeData(this->add,&DATA),"HV: comLoop, setting second command")){return(-1);}  //Value 
+    DATA = data1;
+    
+    if(!TestError(writeData(add, &DATA), "HV: comLoop, setting first command"))
+        return -1;   //Command
+    
+    if (data2 > -1){
+        DATA = data2;
+        if(!TestError(writeData(add, &DATA), "HV: comLoop, setting second command"))
+            return -1;  //Value 
     }
     
-    DATA=0x0000;
-    if(!TestError(writeData(this->add+0x04,&DATA),"HV: comLoop, ordering to send a command")){cout<<"Error?"<<endl;} //Send command
-    if(getStatus()==0xFFFF){
-      if(vLevel(ERROR))cout<<"** ERROR while sending "<<show_hex(data1,4)<<"&"<<show_hex(data2,4)<<endl;
-      return(-1);
+    DATA = 0x0000;
+    
+    if (!TestError(writeData(add + 0x04, &DATA), "HV: comLoop, ordering to send a command"))
+        std::cout << "Error?" << std::endl; //Send command
+
+    if (getStatus() == 0xFFFF) {
+        if (vLevel(ERROR))
+            std::cout << "** ERROR while sending " << show_hex(data1, 4) << "&" << show_hex(data2,4) << std::endl;
+        return -1;
     }
 //     int lbreak=0;
 //     
@@ -56,27 +73,35 @@ int hv::comLoop(int data1, int data2){
 //       DATA=0;
 //       if(TestError(readData(this->add+0x00,&DATA),"HV: comLoop, reading")){cout<<"Word "<<lbreak<<" "<<show_hex(DATA)<<endl;}    
 //     }
-    return(1);
+    return 1;
     //DATA=getStatus();
     //if(DATA==0xFFFF){cerr<<"ERROR!!!"<<endl;}
   
 }
-int hv::setChState(bool state, int channel){
-  if (channel<0){
-    int status=1;
-    for (int i=0; i<4; i++){
-      if(setChState(state,i)<0)status=-1;
+
+int hv::setChState(bool state, int channel) {
+    if (channel < 0) {
+        
+        int status = 1;
+    
+        for (int i = 0; i < 4; i++) {
+            if(setChState(state, i) < 0)
+                status = -1;
+        }
+    
+        return status;
+  
+    } else if (channel > 3) {
+    
+        if (vLevel(WARNING))
+            std::cerr << "*   WARNING: invalid parameter: " << channel << ". Statement ignored" << std::endl;
+        return -1;
+    
+    } else {
+        return comLoop(channel * 256 + 0x000B - state);
     }
-    return(status);
-  }
-  else if(channel>3){
-    if(vLevel(WARNING)) cerr<<"*   WARNING: invalid parameter: "<<channel<<". Statement ignored"<<endl;
-    return(-1);
-  }
-  else{
-    return(comLoop(channel*256+0x000B-state));
-  }
 }
+
 int hv::setChV(int volt, int channel){
   if (channel<0){
     int status=1;

--- a/CosmicTrigger/include/HV.h
+++ b/CosmicTrigger/include/HV.h
@@ -23,97 +23,97 @@ using namespace std;
  */
 
 
-class hv:public vmeBoard{
-public:
-  hv(vmeController *cont,int bridgeAdd=0x900000, int hvAdd=0x09);
-  /**<
-   * 
-   * \brief Constructor
-   * 
-   * This constructor sets up the basic Board address and the High voltage unit's address.
-   * 
-   * 
-   */
-    
-  int comLoop(int data1,int data2=-1);
-  /**
-   * 
-   * \brief Implements H.S. CAENET communication protocol.
-   * 
-   * This function will send to the LEMO cable:
-   * 
-   * -A hello signal
-   *
-   * -The address of the slave device (hvAdd implemented in the constructor and can be changed with setHvAdd() )
-   * 
-   * -The first data byte (data1)
-   * 
-   * -If necessary (not -1), the second data byte
-   * 
-   * Then, after writing in the "send register" of the bridge, the "status register" will be read.
-   * 
-   * This function returns 1 if everything went as expected, 0 if not.
-   * 
-   * 
-   */
-  
-  int setChState(bool state, int channel=-1);
-  /**
-   * \brief Sets channel on/off.
-   * 
-   * This function will send a command to the High Voltage to set the given channel on (state=0) or off(state=1).
-   * 
-   * If the channel is not specified or set to -1, the function will set all 4 channels on/off.
-   * 
-   * This function returns 1 if everything worked and -1 if not.
-   * 
-   */
-  
-  int setChV(int volt,int channel=-1);
-   /**
-   * \brief Sets channel's voltage.
-   * 
-   * This function will send a command to the High Voltage to set the given channel to the given voltage.
-   * 
-   * If the channel is not specified or set to -1, the function will set all 4 channels to that voltage.
-   * 
-   * This function returns 1 if everything worked and -1 if not.
-   * 
-   */
+class hv: public vmeBoard {
 
-  double ** readValues(double ** data=0);
-  /**
-   * \brief Reads bridge i/o register
-   * 
-   * This function will read the value stored on the bridge's i/o register.
-   * 
-   * If the slave wrote on it correctly, the function will return 1. 
-   * 
-   * If there is a communication problem, or if the slave did not write on the bridge, the function returns -1
-   * 
-   */
+    public:
   
-  int reset(void);///<Resets the bridge.
+        hv(vmeController *cont, int bridgeAdd = 0x900000, int hvAdd = 0x09);
+        /**<
+         * 
+         * \brief Constructor
+         * 
+         * This constructor sets up the basic Board address and the High voltage unit's address.
+         * 
+         * 
+         */
+          
+        int comLoop(int data1, int data2 = -1);
+        /**
+         * 
+         * \brief Implements H.S. CAENET communication protocol.
+         * 
+         * This function will send to the LEMO cable:
+         * 
+         * -A hello signal
+         *
+         * -The address of the slave device (hvAdd implemented in the constructor and can be changed with setHvAdd() )
+         * 
+         * -The first data byte (data1)
+         * 
+         * -If necessary (not -1), the second data byte
+         * 
+         * Then, after writing in the "send register" of the bridge, the "status register" will be read.
+         * 
+         * This function returns 1 if everything went as expected, 0 if not.
+         * 
+         * 
+         */
+        
+        int setChState(bool state, int channel = -1);
+        /**
+         * \brief Sets channel on/off.
+         * 
+         * This function will send a command to the High Voltage to set the given channel on (state=0) or off(state=1).
+         * 
+         * If the channel is not specified or set to -1, the function will set all 4 channels on/off.
+         * 
+         * This function returns 1 if everything worked and -1 if not.
+         * 
+         */
+        
+        int setChV(int volt, int channel = -1);
+         /**
+         * \brief Sets channel's voltage.
+         * 
+         * This function will send a command to the High Voltage to set the given channel to the given voltage.
+         * 
+         * If the channel is not specified or set to -1, the function will set all 4 channels to that voltage.
+         * 
+         * This function returns 1 if everything worked and -1 if not.
+         * 
+         */
+
+        double ** readValues(double ** data = 0);
+        /**
+         * \brief Reads bridge i/o register
+         * 
+         * This function will read the value stored on the bridge's i/o register.
+         * 
+         * If the slave wrote on it correctly, the function will return 1. 
+         * 
+         * If there is a communication problem, or if the slave did not write on the bridge, the function returns -1
+         * 
+         */
+        
+        int reset(void);///<Resets the bridge.
+        
+        int getStatus(void);
+        /**
+         * \brief Reads the status register.
+         * 
+         * When writing data in the "i/o register" or in the "send register", the bridge will set this status register to tell if the action was valid or not.
+         * 
+         * If the action was valid, it returns 0xFFFE. If not, it returns 0xFFFF.
+         * 
+         * 
+         */
+        
+        void setHvAdd(int add) { hvAdd = add; } ///<Allows to change the HV's address.
   
-  int getStatus(void);
-  /**
-   * \brief Reads the status register.
-   * 
-   * When writing data in the "i/o register" or in the "send register", the bridge will set this status register to tell if the action was valid or not.
-   * 
-   * If the action was valid, it returns 0xFFFE. If not, it returns 0xFFFF.
-   * 
-   * 
-   */
   
-  void setHvAdd(int add){hvAdd=add;}///<Allows to change the HV's address.
-  
-  
-private:
-  int hvAdd;
-  
+    private:
+        
+        int hvAdd;
 };
-
-
 
 #endif

--- a/CosmicTrigger/include/VmeBoard.cpp
+++ b/CosmicTrigger/include/VmeBoard.cpp
@@ -1,40 +1,40 @@
 #include "VmeBoard.h"
 
+vmeBoard::vmeBoard(vmeController* cont, AddressModifier AM, DataWidth DW):
+    cont(cont),
+    AM(AM),
+    DW(DW) {}
 
-vmeBoard::vmeBoard(vmeController* cont,AddressModifier AM,DataWidth DW){
-  this->cont=cont;
+bool vmeBoard::vLevel(coutLevel level) {
+    return cont->verbose >= (int)level;
+}
+
+int vmeBoard::writeData(long unsigned int add, void *DATA) {
+  return cont->writeData(add, DATA, AM, DW);
+}
+
+int vmeBoard::readData(long unsigned int add, void *DATA) {
+  return cont->readData(add, DATA, AM, DW); 
+}
+
+int vmeBoard::writeData(long unsigned int add, void *DATA, AddressModifier tAM, DataWidth tDW) {
+  return cont->writeData(add, DATA, tAM, tDW);
+}
+
+int vmeBoard::readData(long unsigned int add, void *DATA, AddressModifier tAM, DataWidth tDW) {
+  return cont->readData(add, DATA, tAM, tDW);
+}
+
+void vmeBoard::setAM(AddressModifier AM) {
   this->AM=AM;
+}
+
+void vmeBoard::setDW(DataWidth DW) {
   this->DW=DW;
 }
 
-bool vmeBoard::vLevel(coutLevel level){
-    return(this->cont->verbose>=(int)level);
-}
 
-
-int vmeBoard::writeData(long unsigned int add, void *DATA){
-  return(cont->writeData(add,DATA,AM,DW));
-}
-
-int vmeBoard::readData(long unsigned int add, void *DATA){
-  return(cont->readData(add,DATA,AM,DW)); 
-}
-int vmeBoard::writeData(long unsigned int add, void *DATA,AddressModifier tAM, DataWidth tDW){
-  return(cont->writeData(add,DATA,tAM,tDW));
-}
-int vmeBoard::readData(long unsigned int add, void *DATA,AddressModifier tAM, DataWidth tDW){
-  return(cont->readData(add,DATA,tAM,tDW));
-}
-
-void vmeBoard::setAM(AddressModifier AM){
-  this->AM=AM;
-}
-void vmeBoard::setDW(DataWidth DW){
-  this->DW=DW;
-}
-
-
-bool vmeBoard::TestError(int erreur,string endroit, bool fatal){
+/*bool vmeBoard::TestError(int erreur,string endroit, bool fatal){
   int out=1;
   if(!erreur==0){
     if (fatal&&vLevel(SILENT)){
@@ -54,4 +54,4 @@ bool vmeBoard::TestError(int erreur,string endroit, bool fatal){
     out=1;
   }
   return(out);
-}
+}*/

--- a/CosmicTrigger/include/VmeBoard.h
+++ b/CosmicTrigger/include/VmeBoard.h
@@ -21,102 +21,102 @@
 
 class vmeBoard{
   
-  
-public:
-  vmeBoard(vmeController* cont,AddressModifier AM=A32_U_DATA,DataWidth DW=D16);
-  /**< \brief Constructor
-   * 
-   *  When a daughter card is created, it will call this constructor. The vmeController pointer is always given, and if the card uses special AddressModifier or DataWidth, those argument should be sent then.
-   * 
-   * If, for some reason, those default AM/DW values have to be changed, the functions setDW() or setAM() should be used.
-   * 
-   * 
-   */
-  
-protected:
-  vmeController* Controller(void) { return cont; }/**<\brief Allows daughter class to get the controller*/
-  
-  int writeData(long unsigned int add, void *DATA);
-  /**<\brief Uses default values
-  *
-  *This function will use the virtual controller functions with the stored data in order to communicate with a daughter board.
-  * 
-  *The add parameter is the address of the register (not the board!) to be accessed and *DATA a pointer towards any type and will be used to send the appropriate number of bits to the VME Board.
-  * 
-  * The amount of bits send is stored in DW and can be modified with setDW.
-  *
-  */
-  
-  int readData(long unsigned int add, void *DATA);
-  /**<\brief Uses default values
-  *
-  *This function will use the virtual controller functions with the stored data in order to communicate with a daughter board.
-  * 
-  * The add parameter is the address of the register (not the board!) to be accessed and *DATA a pointer towards any type and will be used to read the appropriate number of bits to the VME Board.
-  * 
-  * The default DW and AM are set when the vmeBoard is created but can be changed with setDW or setAM.
-  *
-  */  
-
-  
-  int writeData(long unsigned int add, void *DATA,AddressModifier tAM, DataWidth tDW);
-  /**<\brief Uses temporary values
-   *
-   * This write function will use the virtual controller's write function with the given parameters.
-   *
-   */
-  
-  int readData(long unsigned int add, void *DATA,AddressModifier tAM, DataWidth tDW);
-    /**<\brief Uses temporary values
-   *
-   * This read function will use the virtual controller's read function with the given parameters.
-   *
-   */
-
-  
-  void setAM(AddressModifier AM);
-  /**< \brief Saves default value
-   *
-   * This function allows the user to change the stored AddressModifier value that will be used to communicate with the Board if no parameter is specified.
-   *
-   */
-  
-  void setDW(DataWidth DW);
-  /**< \brief Saves default value
-   *
-   * This function allows the user to change the stored DataWidth value that will be used to communicate with the Board if no parameter is specified.
-   *
-   */
-
-  bool vLevel(coutLevel level);
-  /**< \brief Checks the verbosity level.
-   * 
-   * This function will access the verbosity level of the vmeController and return 1 if the given level is above the controller's level.
-   * 
-   * It allows the controller to choose what messages should be displayed.
-   * 
-   * The possible values for the level are: SILENT, ERROR, WARNING, NORMAL and DEBUG.
-   * 
-   */
-  
-  void setAdd(int add){this->add=add;}///<Changes the address of the board.
-  
-  bool TestError(int erreur,string endroit="",bool fatal=false);
- /**<
- * \brief Handles errors.
- * 
- * \param erreur Return value of a readData or writeData function. This will be shown in an error message if useful.
- * \param endroit1 String indicating the place of the error. Will be shown in error message.
- * \param fatal If set to true, the program exists.
- * 
- */
-
-
-  int add;
-private:
-  AddressModifier AM; ///< Stored AM value
-  DataWidth DW; ///<Stored DW value
-  vmeController *cont; ///<Pointer to the controller. Only this class can access it.
+    public:
+        
+        vmeBoard(vmeController* cont, AddressModifier AM = A32_U_DATA, DataWidth DW = D16);
+        /**< \brief Constructor
+         * 
+         *  When a daughter card is created, it will call this constructor. The vmeController pointer is always given, and if the card uses special AddressModifier or DataWidth, those argument should be sent then.
+         * 
+         * If, for some reason, those default AM/DW values have to be changed, the functions setDW() or setAM() should be used.
+         * 
+         * 
+         */
+      
+    protected:
+      
+        vmeController* Controller(void) { return cont; } /**<\brief Allows daughter class to get the controller*/
+      
+        int writeData(long unsigned int add, void *DATA);
+        /**<\brief Uses default values
+        *
+        *This function will use the virtual controller functions with the stored data in order to communicate with a daughter board.
+        * 
+        *The add parameter is the address of the register (not the board!) to be accessed and *DATA a pointer towards any type and will be used to send the appropriate number of bits to the VME Board.
+        * 
+        * The amount of bits send is stored in DW and can be modified with setDW.
+        *
+        */
+        
+        int readData(long unsigned int add, void *DATA);
+        /**<\brief Uses default values
+        *
+        *This function will use the virtual controller functions with the stored data in order to communicate with a daughter board.
+        * 
+        * The add parameter is the address of the register (not the board!) to be accessed and *DATA a pointer towards any type and will be used to read the appropriate number of bits to the VME Board.
+        * 
+        * The default DW and AM are set when the vmeBoard is created but can be changed with setDW or setAM.
+        *
+        */  
+    
+        int writeData(long unsigned int add, void *DATA, AddressModifier tAM, DataWidth tDW);
+        /**<\brief Uses temporary values
+         *
+         * This write function will use the virtual controller's write function with the given parameters.
+         *
+         */
+        
+        int readData(long unsigned int add, void *DATA, AddressModifier tAM, DataWidth tDW);
+          /**<\brief Uses temporary values
+         *
+         * This read function will use the virtual controller's read function with the given parameters.
+         *
+         */
+    
+        void setAM(AddressModifier AM);
+        /**< \brief Saves default value
+         *
+         * This function allows the user to change the stored AddressModifier value that will be used to communicate with the Board if no parameter is specified.
+         *
+         */
+        
+        void setDW(DataWidth DW);
+        /**< \brief Saves default value
+         *
+         * This function allows the user to change the stored DataWidth value that will be used to communicate with the Board if no parameter is specified.
+         *
+         */
+    
+        bool vLevel(coutLevel level);
+        /**< \brief Checks the verbosity level.
+         * 
+         * This function will access the verbosity level of the vmeController and return 1 if the given level is above the controller's level.
+         * 
+         * It allows the controller to choose what messages should be displayed.
+         * 
+         * The possible values for the level are: SILENT, ERROR, WARNING, NORMAL and DEBUG.
+         * 
+         */
+        
+        void setAdd(int add) { this->add = add; } ///<Changes the address of the board.
+        
+        //bool TestError(int erreur,string endroit="",bool fatal=false);
+        /**<
+        * \brief Handles errors.
+        * 
+        * \param erreur Return value of a readData or writeData function. This will be shown in an error message if useful.
+        * \param endroit1 String indicating the place of the error. Will be shown in error message.
+        * \param fatal If set to true, the program exists.
+        * 
+        */
+    
+      int add;
+    
+    private:
+        
+        AddressModifier AM; ///< Stored AM value
+        DataWidth DW; ///<Stored DW value
+        vmeController *cont; ///<Pointer to the controller. Only this class can access it.
 };
 
 #endif

--- a/CosmicTrigger/include/VmeController.h
+++ b/CosmicTrigger/include/VmeController.h
@@ -19,20 +19,26 @@ using namespace std;
  * It has been created in order to be able to control any VME based system and therefore, the functions are pure virtual.
  * 
  */
-class vmeController{
-public:
-  virtual   void setMode(AddressModifier AM, DataWidth DW)=0;///<Sets default modes.
-  virtual   int writeData(long unsigned int address,void* data)=0;///<Short write data function using default modes.
-  virtual   int readData(long unsigned int address,void* data)=0;///<Short read data function using default modes.
-  virtual   int writeData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW)=0;///<Write data function using given mode.
-  virtual   int readData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW)=0;///<Read data function using given mode.
-  int verbose; ///<Defines verbosity level of any board using this controller
+class vmeController  {
+    
+    public:
+        
+        vmeController(int verbose):
+            verbose(verbose) {}
+
+        virtual void setMode(AddressModifier AM, DataWidth DW) = 0; ///<Sets default modes.
+        virtual int writeData(long unsigned int address,void* data) = 0; ///<Short write data function using default modes.
+        virtual int readData(long unsigned int address,void* data) = 0; ///<Short read data function using default modes.
+        virtual int writeData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW) = 0; ///<Write data function using given mode.
+        virtual int readData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW) = 0; ///<Read data function using given mode.
+        
+        void setVerbose(int verbose){ this->verbose = verbose; } ///< Sets verbosity level
+        
+        virtual AddressModifier getAM(void) = 0; ///<Gets default mode
+        virtual DataWidth getDW(void) = 0; ///<Gets default mode
   
-  void setVerbose(int verbose){this->verbose=verbose;}///< Sets verbosity level
-  
-  virtual AddressModifier getAM(void)=0;///<Gets default mode
-  virtual DataWidth getDW(void)=0;///<Gets default mode
-  
+    protected:
+        int verbose; ///<Defines verbosity level of any board using this controller
 };
 
 #endif

--- a/CosmicTrigger/include/VmeUsbBridge.cpp
+++ b/CosmicTrigger/include/VmeUsbBridge.cpp
@@ -1,53 +1,53 @@
-#include "VmeUsbBridge.h"
 #include <iostream>
-using namespace std;
 
-UsbController::UsbController(int verbose){
-  this->verbose=verbose;
-  this->board=V1718;
-  int32_t *handle = new int32_t;
-  m_status = CAENVME_Init((CVBoardTypes)(int)board, 0, 0, handle);
-  this->BHandle=handle;
-  this->AM=A32_S_DATA;
-  this->DW=D16;
-  if (m_status==0)cout<<"VME USB Init... ok!"<<endl;
-  else {
-    cout<<"***FATAL ERROR: "<< m_status <<" when starting usb board"<<endl;
-  }
+#include "VmeUsbBridge.h"
+
+UsbController::UsbController(int verbose):
+    vmeController(verbose) {
+    
+    board = V1718;
+    int32_t *handle = new int32_t;
+    m_status = CAENVME_Init((CVBoardTypes)(int)board, 0, 0, handle);
+    BHandle = handle;
+    AM = A32_S_DATA;
+    DW = D16;
+    
+    if (m_status == 0)
+        std::cout << "VME USB Init... ok!" << std::endl;
+    else
+      std::cout << "***FATAL ERROR: " << m_status << " when starting usb board" << std::endl;
 }
 
-
-
-
-void UsbController::setMode(AddressModifier AM, DataWidth DW){
-  this->AM=AM;
-  this->DW=DW;
+void UsbController::setMode(AddressModifier AM, DataWidth DW) {
+    this->AM = AM;
+    this->DW = DW;
 }
 
-int UsbController::writeData(long unsigned int address,void* data){
-  return(CAENVME_WriteCycle(*this->BHandle,address,data,(CVAddressModifier)(int)this->AM,(CVDataWidth)(int)this->DW));
+int UsbController::writeData(long unsigned int address, void* data) {
+    return CAENVME_WriteCycle(*BHandle, address, data, (CVAddressModifier)(int)AM, (CVDataWidth)(int)DW);
 }
 
-int UsbController::readData(long unsigned int address,void* data){
-    return(CAENVME_ReadCycle(*this->BHandle,address,data,(CVAddressModifier)(int)this->AM,(CVDataWidth)(int)this->DW));
+int UsbController::readData(long unsigned int address, void* data) {
+    return CAENVME_ReadCycle(*BHandle, address, data, (CVAddressModifier)(int)AM,(CVDataWidth)(int)DW);
 }
 
-int UsbController::writeData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW){
-  return(CAENVME_WriteCycle(*this->BHandle,address,data,(CVAddressModifier)(int)AM,(CVDataWidth)(int)DW));
+int UsbController::writeData(long unsigned int address, void* data,AddressModifier AM, DataWidth DW) {
+    return CAENVME_WriteCycle(*BHandle, address, data, (CVAddressModifier)(int)AM, (CVDataWidth)(int)DW);
 }
 
-int UsbController::readData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW){
-  return(CAENVME_ReadCycle(*this->BHandle,address,data,(CVAddressModifier)(int)AM,(CVDataWidth)(int)DW));
+int UsbController::readData(long unsigned int address, void* data, AddressModifier AM, DataWidth DW) {
+    return CAENVME_ReadCycle(*BHandle,address, data, (CVAddressModifier)(int)AM, (CVDataWidth)(int)DW);
 }
 
-AddressModifier UsbController::getAM(void){
-  return(this->AM);
-  
+AddressModifier UsbController::getAM(void) {
+    return AM;
 }
-DataWidth UsbController::getDW(void){
-  return(this->DW);
+
+DataWidth UsbController::getDW(void) {
+    return DW;
 }
-UsbController::~UsbController(){
- CAENVME_End(*this->BHandle);
- cout<<"Exiting controller"<<endl; 
+
+UsbController::~UsbController() {
+    CAENVME_End(*BHandle);
+    std::cout << "Exiting controller" << std::endl; 
 }

--- a/CosmicTrigger/include/VmeUsbBridge.h
+++ b/CosmicTrigger/include/VmeUsbBridge.h
@@ -5,7 +5,6 @@
 #include "CAENVMEoslib.h"
 #include "CAENVMEtypes.h"
 
-
 #include "VmeController.h"
 
 /**
@@ -17,45 +16,48 @@
  * 
  */
 
-class UsbController: public vmeController{
-public:
-     UsbController(int verbose=3);
-     /**< 
-      * \brief Class constructor.
-      * 
-      * This constructor will create the object "BHandle" and store it. It also will set a few default modes and check 
-      * if the link to the VME is ok.
-      * 
-      */
-     
-     ~UsbController();///< Liberates the USB controller and "BHandle    
-     void setMode(AddressModifier AM, DataWidth DW);
-     int writeData(long unsigned int address,void* data);
-     int readData(long unsigned int address,void* data);
-     int writeData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW);
-     int readData(long unsigned int address,void* data,AddressModifier AM, DataWidth DW);
-     int getStatus() { return m_status; }
+class UsbController: public vmeController {
 
+    public:
+        
+        UsbController(int verbose = 3);
+        /**< 
+         * \brief Class constructor.
+         * 
+         * This constructor will create the object "BHandle" and store it. It also will set a few default modes and check 
+         * if the link to the VME is ok.
+         * 
+         */
+        
+        ~UsbController();///< Liberates the USB controller and "BHandle    
+        void setMode(AddressModifier AM, DataWidth DW);
+        int writeData(long unsigned int address, void* data);
+        int readData(long unsigned int address, void* data);
+        int writeData(long unsigned int address, void* data, AddressModifier AM, DataWidth DW);
+        int readData(long unsigned int address, void* data, AddressModifier AM, DataWidth DW);
+        int getStatus() { return m_status; }
 
-     AddressModifier getAM(void);
-     DataWidth getDW(void);
-     
-private:
-  AddressModifier AM;
-  DataWidth DW;
-  int32_t* BHandle;
-  int m_status;
-  /**<
-   * 
-   * \brief Communication identifier.
-   * 
-   * This object is primordial in any communication with the VME bridge. It is used every single time DATA has to be transfered from the 
-   * host computer to a VME Board.
-   * 
-   * It is created with the class and will die with the class. Long live BHandle!
-   * 
-   */
-  BoardTypes board;
+        AddressModifier getAM(void);
+        DataWidth getDW(void);
+
+    private:
+        
+        AddressModifier AM;
+        DataWidth DW;
+        int32_t* BHandle;
+        int m_status;
+        
+        /**<
+         * 
+         * \brief Communication identifier.
+         * 
+         * This object is primordial in any communication with the VME bridge. It is used every single time DATA has to be transfered from the 
+         * host computer to a VME Board.
+         * 
+         * It is created with the class and will die with the class. Long live BHandle!
+         * 
+         */
+        BoardTypes board;
 };
 
 #endif

--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -25,9 +25,9 @@ class ConditionManager {
             m_interface(m_interface),
             m_state(State::idle),
             m_hvpmt({
-                    { 1025, 0, false, 1, 0, false },
-                    { 925, 0, false, 1, 0, false },
-                    { 1225, 0, false, 1, 0, false },
+                    { 1025, 1025, false, 0, 0, false },
+                    { 925, 925, false, 0, 0, false },
+                    { 1225, 1225, false, 0, 0, false },
                     { 0, 0, false, 0, 0, false }
                     })
         {
@@ -103,9 +103,8 @@ class ConditionManager {
          */
         static bool checkTransition(ConditionManager::State state_from, ConditionManager::State state_to);
         
-        void lock() { m_mtx.lock(); }
-        void unlock() { m_mtx.unlock(); }
-        std::mutex& getLock() { return m_mtx; }
+        std::mutex& getHVLock() { return m_hv_mtx; }
+        std::mutex& getTDCLock() { return m_tdc_mtx; }
 
         /*
          * Define/retrieve the PMT HV value (no action taken on the setup)
@@ -134,7 +133,8 @@ class ConditionManager {
 
     private:
 
-        std::mutex m_mtx;
+        std::mutex m_hv_mtx;
+        std::mutex m_tdc_mtx;
 
         Interface& m_interface;
         std::atomic<State> m_state;

--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -13,7 +13,6 @@ class ConditionManager {
     public:
 
         ConditionManager(): 
-            counter(0),
             m_hvpmt_setStates({1, 1, 1, 0}),
             m_hvpmt_setValues({1025, 925, 1225, 0}),
             m_state(State::idle)
@@ -69,8 +68,6 @@ class ConditionManager {
         void unlock() { m_mtx.unlock(); }
         std::mutex& getLock() { return m_mtx; }
 
-        void setCounter(int c) { counter = c; }
-        int getCounter() const { return counter; }
         /*
          * Define/retrieve the PMT HV value (no action taken on the setup)
          * So far, this is a vector with entry==channel
@@ -93,8 +90,6 @@ class ConditionManager {
         static const std::vector< std::pair<State, State> > m_transitions;
 
     private:
-
-        std::atomic<int> counter;
 
         std::mutex m_mtx;
 

--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -9,6 +9,12 @@
 #include <string>
 #include <cstddef>
 
+#include "SetupManager.h"
+#include "Interface.h"
+#include "RealSetupManager.h"
+#include "FakeSetupManager.h"
+#include "VmeUsbBridge.h"
+
 class Interface;
 
 class ConditionManager {
@@ -25,6 +31,18 @@ class ConditionManager {
                     { 0, 0, false, 0, 0, false }
                     })
         {
+            std::cout << "Checking if the PC is connected to board..." << std::endl;
+            UsbController *dummy_controller = new UsbController(DEBUG);
+            bool canTalkToBoards = (dummy_controller->getStatus() == 0);
+            std::cout << "Deleting dummy USB controller..." << std::endl;
+            delete dummy_controller;
+            if (canTalkToBoards) {
+                std::cout << "You are on 'the' machine connected to the boards and can take action on them." << std::endl;
+                m_setup_manager = std::make_shared<RealSetupManager>(m_interface);
+            } else {
+                std::cout << "WARNING : You are not on 'the' machine connected to the boards. Actions on the setup will be ignored." << std::endl;
+                m_setup_manager = std::make_shared<FakeSetupManager>();
+            }
 
             // for testing purposes
             setState(State::configured);
@@ -125,4 +143,6 @@ class ConditionManager {
         std::thread thread_handle_TDC;
 
         std::vector<HVPMT> m_hvpmt;
+        
+        std::shared_ptr<SetupManager> m_setup_manager;
 };

--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -110,8 +110,8 @@ class ConditionManager {
          * Define/retrieve the PMT HV value (no action taken on the setup)
          * So far, this is a vector with entry==channel
          */
-        void setHVPMTValue(std::size_t id, int value);
-        void setHVPMTState(std::size_t id, int state);
+        int setHVPMTValue(std::size_t id, int value);
+        bool setHVPMTState(std::size_t id, int state);
         int getHVPMTSetValue(std::size_t id) const { return m_hvpmt.at(id).setValue; }
         int getHVPMTReadValue(std::size_t id) const { return m_hvpmt.at(id).readValue; }
         int getHVPMTSetState(std::size_t id) const { return m_hvpmt.at(id).setState; }

--- a/include/FakeSetupManager.h
+++ b/include/FakeSetupManager.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <cstddef>
+
 #include "SetupManager.h"
 
-class FakeSetupManager : public SetupManager {
+class FakeSetupManager: public SetupManager {
     
     public:
 
-        virtual void setHVPMT() override;
-        virtual void switchHVPMTON() override;
-        virtual void switchHVPMTOFF() override;
+        virtual ~FakeSetupManager() override {};
+
+        virtual void setHVPMT(std::size_t id) override;
+        virtual void switchHVPMTON(std::size_t id) override;
+        virtual void switchHVPMTOFF(std::size_t id) override;
 };

--- a/include/FakeSetupManager.h
+++ b/include/FakeSetupManager.h
@@ -10,7 +10,7 @@ class FakeSetupManager: public SetupManager {
 
         virtual ~FakeSetupManager() override {};
 
-        virtual void setHVPMT(std::size_t id) override;
-        virtual void switchHVPMTON(std::size_t id) override;
-        virtual void switchHVPMTOFF(std::size_t id) override;
+        virtual bool setHVPMT(std::size_t id) override;
+        virtual bool switchHVPMTON(std::size_t id) override;
+        virtual bool switchHVPMTOFF(std::size_t id) override;
 };

--- a/include/HVGroup.h
+++ b/include/HVGroup.h
@@ -9,6 +9,7 @@
 #include <QPushButton>
 
 #include <memory>
+#include <cstddef>
 
 class Interface;
 
@@ -20,12 +21,12 @@ class HVGroup : public QWidget {
     public:
         HVGroup(Interface& m_interface);
         virtual ~HVGroup() {}
+        
         struct HVEntry {
             QLabel *label;
             QLabel *value_label;
             QSpinBox *spin_box;
         };
-
 
     private slots:
         //void valueChanged(int m_hv);

--- a/include/HVGroup.h
+++ b/include/HVGroup.h
@@ -28,6 +28,9 @@ class HVGroup : public QWidget {
             QSpinBox *spin_box;
         };
 
+    public:
+        void notifyUpdate();
+
     private slots:
         //void valueChanged(int m_hv);
         void setRunning();

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -5,6 +5,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QGridLayout>
+#include <QTimer>
 
 #include <thread>
 #include <memory>
@@ -25,12 +26,11 @@ class Interface : public QWidget {
 
         ConditionManager& getConditions();
 
-        void notifyUpdate();
-
         bool isRunning() const { return running; }
 
     public slots:
         void updateConditionLog();
+        void notifyUpdate();
 
     private slots:
         void startLoggingManager();
@@ -41,6 +41,10 @@ class Interface : public QWidget {
         void setCounter(int i);
 
         HVGroup* m_hv_group;
+        
+        // Use a timer to refresh the interface periodically
+        QTimer* m_timer;
+        
         std::shared_ptr<LoggingManager> m_logging_manager;
         std::shared_ptr<ConditionManager> m_conditions;
         std::thread thread_handler;

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -9,8 +9,8 @@
 #include <thread>
 #include <memory>
 
-#include <unistd.h>
-#include <sys/param.h>
+//#include <unistd.h>
+//#include <sys/param.h>
 
 #include "SetupManager.h"
 #include "RealSetupManager.h"
@@ -28,7 +28,15 @@ class Interface : public QWidget {
 
     public:
         Interface(QWidget *parent = 0);
-        virtual ~Interface() {}
+
+        /*
+         * FIXME
+         */
+        virtual ~Interface() {
+            m_logging_manager.reset(); 
+            m_conditions.reset();
+            m_setup_manager.reset();
+        }
 
         ConditionManager& getConditions();
 
@@ -36,6 +44,9 @@ class Interface : public QWidget {
 
         bool isRunning() const { return running; }
         const std::shared_ptr<SetupManager>& getSetupManager() const { return m_setup_manager; }
+
+    public slots:
+        void updateConditionLog();
 
     private slots:
         void startLoggingManager();

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -35,25 +35,22 @@ class Interface : public QWidget {
         void notifyUpdate();
 
         bool isRunning() const { return running; }
-        SetupManager* getSetupManager() const { return m_setup_manager; }
+        const std::shared_ptr<SetupManager>& getSetupManager() const { return m_setup_manager; }
 
     private slots:
         void startLoggingManager();
         void stopLoggingManager();
-        void onPlus();
-        void onMinus();
 
     private:
       
         void setCounter(int i);
 
-        QLabel* label;
         HVGroup* m_hv_group;
         std::shared_ptr<LoggingManager> m_logging_manager;
         std::shared_ptr<ConditionManager> m_conditions;
         std::thread thread_handler;
 
-        SetupManager* m_setup_manager;
+        std::shared_ptr<SetupManager> m_setup_manager;
 
         bool running;
 };

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -9,17 +9,9 @@
 #include <thread>
 #include <memory>
 
-//#include <unistd.h>
-//#include <sys/param.h>
-
-#include "SetupManager.h"
-#include "RealSetupManager.h"
-#include "FakeSetupManager.h"
-
-#include "LoggingManager.h"
-#include "ConditionManager.h"
-#include "HVGroup.h"
-
+class ConditionManager;
+class LoggingManager;
+class HVGroup;
 
 class Interface : public QWidget {
     friend class HVGroup;
@@ -29,21 +21,13 @@ class Interface : public QWidget {
     public:
         Interface(QWidget *parent = 0);
 
-        /*
-         * FIXME
-         */
-        virtual ~Interface() {
-            m_logging_manager.reset(); 
-            m_conditions.reset();
-            m_setup_manager.reset();
-        }
+        virtual ~Interface() {}
 
         ConditionManager& getConditions();
 
         void notifyUpdate();
 
         bool isRunning() const { return running; }
-        const std::shared_ptr<SetupManager>& getSetupManager() const { return m_setup_manager; }
 
     public slots:
         void updateConditionLog();
@@ -60,8 +44,6 @@ class Interface : public QWidget {
         std::shared_ptr<LoggingManager> m_logging_manager;
         std::shared_ptr<ConditionManager> m_conditions;
         std::thread thread_handler;
-
-        std::shared_ptr<SetupManager> m_setup_manager;
 
         bool running;
 };

--- a/include/LoggingManager.h
+++ b/include/LoggingManager.h
@@ -16,19 +16,21 @@ class Interface;
  */
 class LoggingManager {
   public:
+      
+      using m_clock = std::chrono::system_clock;
 
       LoggingManager(Interface& m_interface, uint32_t m_continuous_log_time = 1000, uint32_t m_interface_refresh_time = 250);
       ~LoggingManager() {};
 
       void run();
       void stop();
+      
+      // Public: if interface changes something during a run, we have to update
+      void updateConditionManagerLog(bool first_time = false, m_clock::time_point log_time = m_clock::now());
   
   private:
         
-      using m_clock = std::chrono::system_clock;
-
       void initConditionManagerLog();
-      void updateConditionManagerLog(m_clock::time_point log_time, bool first_time = false);
       void finalizeConditionManagerLog();
       
       void initContinuousLog();

--- a/include/RealSetupManager.h
+++ b/include/RealSetupManager.h
@@ -18,9 +18,9 @@ class RealSetupManager: public SetupManager {
          */
         virtual ~RealSetupManager() override;
 
-        virtual void setHVPMT(size_t id) override;
-        virtual void switchHVPMTON(size_t id) override;
-        virtual void switchHVPMTOFF(size_t id) override;
+        virtual bool setHVPMT(size_t id) override;
+        virtual bool switchHVPMTON(size_t id) override;
+        virtual bool switchHVPMTOFF(size_t id) override;
 
     private:
 

--- a/include/RealSetupManager.h
+++ b/include/RealSetupManager.h
@@ -1,19 +1,26 @@
 #pragma once
 
+#include <cstddef>
+
 #include "SetupManager.h"
 #include "VmeUsbBridge.h"
 #include "HV.h"
 
 class Interface;
 
-class RealSetupManager : public SetupManager {
+class RealSetupManager: public SetupManager {
     public:
 
         RealSetupManager(Interface& m_interface);
+        
+        /*
+         * Destructor: turn the HV off
+         */
+        virtual ~RealSetupManager() override;
 
-        virtual void setHVPMT() override;
-        virtual void switchHVPMTON() override;
-        virtual void switchHVPMTOFF() override;
+        virtual void setHVPMT(size_t id) override;
+        virtual void switchHVPMTON(size_t id) override;
+        virtual void switchHVPMTOFF(size_t id) override;
 
     private:
 

--- a/include/SetupManager.h
+++ b/include/SetupManager.h
@@ -6,7 +6,7 @@ class SetupManager {
     public:
         virtual ~SetupManager() {};
 
-        virtual void setHVPMT(std::size_t id) = 0;
-        virtual void switchHVPMTON(std::size_t id) = 0;
-        virtual void switchHVPMTOFF(std::size_t id) = 0;
+        virtual bool setHVPMT(std::size_t id) = 0;
+        virtual bool switchHVPMTON(std::size_t id) = 0;
+        virtual bool switchHVPMTOFF(std::size_t id) = 0;
 };

--- a/include/SetupManager.h
+++ b/include/SetupManager.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <vector>
+#include <cstddef>
 
 class SetupManager {
     public:
-        virtual void setHVPMT() = 0;
-        virtual void switchHVPMTON() = 0;
-        virtual void switchHVPMTOFF() = 0;
+        virtual ~SetupManager() {};
+
+        virtual void setHVPMT(std::size_t id) = 0;
+        virtual void switchHVPMTON(std::size_t id) = 0;
+        virtual void switchHVPMTOFF(std::size_t id) = 0;
 };

--- a/src/ConditionManager.cpp
+++ b/src/ConditionManager.cpp
@@ -2,8 +2,10 @@
 #include <chrono>
 #include <algorithm>
 #include <exception>
+#include <cstddef>
 
 #include "ConditionManager.h"
+#include "Interface.h"
 
 #include "VmeUsbBridge.h"
 #include "HV.h"
@@ -52,8 +54,20 @@ bool ConditionManager::setState(ConditionManager::State state) {
     return true;
 }
 
-void ConditionManager::setHVPMTValue(int HVNumber, int HVValue) {
-    m_hvpmt_setValues.at(HVNumber) = HVValue;
+void ConditionManager::setHVPMTValue(std::size_t id, int value) {
+    if (m_hvpmt.at(id).setValue == value)
+        return;
+
+    m_hvpmt.at(id).valueChanged = true;
+    m_hvpmt.at(id).setValue = value;
+}
+
+void ConditionManager::setHVPMTState(std::size_t id, int state) {
+    if (m_hvpmt.at(id).setState == state)
+        return;
+
+    m_hvpmt.at(id).stateChanged = true;
+    m_hvpmt.at(id).setState = state;
 }
 
 void ConditionManager::startDaemons() {
@@ -74,9 +88,18 @@ void ConditionManager::daemonHV() {
     while(m_state == State::running) {
         // wait some time
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        
-        // - request reading: get promise from card
-        // - await response: read promise from card
+       
+        for (std::size_t id = 0; id < m_hvpmt.size(); id++) {
+            if (m_hvpmt.at(id).stateChanged) {
+                if (m_hvpmt.at(id).setState)
+                    m_interface.getSetupManager()->switchHVPMTON(id);
+                else
+                    m_interface.getSetupManager()->switchHVPMTOFF(id);
+            }
+            if (m_hvpmt.at(id).valueChanged) {
+                m_interface.getSetupManager()->setHVPMT(id);
+            }
+        }
     }
 }
 

--- a/src/ConditionManager.cpp
+++ b/src/ConditionManager.cpp
@@ -88,18 +88,27 @@ void ConditionManager::daemonHV() {
     while(m_state == State::running) {
         // wait some time
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
-       
+      
+        std::lock_guard<std::mutex> m_lock(m_hv_mtx);
+
         for (std::size_t id = 0; id < m_hvpmt.size(); id++) {
             if (m_hvpmt.at(id).stateChanged) {
                 if (m_hvpmt.at(id).setState)
                     m_setup_manager->switchHVPMTON(id);
                 else
                     m_setup_manager->switchHVPMTOFF(id);
+                m_hvpmt.at(id).stateChanged = false;
             }
             if (m_hvpmt.at(id).valueChanged) {
                 m_setup_manager->setHVPMT(id);
+                m_hvpmt.at(id).valueChanged = false;
             }
+       
+            // FIXME
+            m_hvpmt.at(id).readState = m_hvpmt.at(id).setState;
+            m_hvpmt.at(id).readValue = m_hvpmt.at(id).setValue;
         }
+
     }
 }
 

--- a/src/ConditionManager.cpp
+++ b/src/ConditionManager.cpp
@@ -92,12 +92,12 @@ void ConditionManager::daemonHV() {
         for (std::size_t id = 0; id < m_hvpmt.size(); id++) {
             if (m_hvpmt.at(id).stateChanged) {
                 if (m_hvpmt.at(id).setState)
-                    m_interface.getSetupManager()->switchHVPMTON(id);
+                    m_setup_manager->switchHVPMTON(id);
                 else
-                    m_interface.getSetupManager()->switchHVPMTOFF(id);
+                    m_setup_manager->switchHVPMTOFF(id);
             }
             if (m_hvpmt.at(id).valueChanged) {
-                m_interface.getSetupManager()->setHVPMT(id);
+                m_setup_manager->setHVPMT(id);
             }
         }
     }

--- a/src/FakeSetupManager.cpp
+++ b/src/FakeSetupManager.cpp
@@ -1,12 +1,14 @@
 #include "FakeSetupManager.h"
 
-void FakeSetupManager::setHVPMT() {
+#include <cstddef>
+
+void FakeSetupManager::setHVPMT(std::size_t id) {
 }
 
-void FakeSetupManager::switchHVPMTON() {
+void FakeSetupManager::switchHVPMTON(std::size_t id) {
 }
 
-void FakeSetupManager::switchHVPMTOFF() {
+void FakeSetupManager::switchHVPMTOFF(std::size_t id) {
 }
 
 

--- a/src/FakeSetupManager.cpp
+++ b/src/FakeSetupManager.cpp
@@ -2,13 +2,16 @@
 
 #include <cstddef>
 
-void FakeSetupManager::setHVPMT(std::size_t id) {
+bool FakeSetupManager::setHVPMT(std::size_t id) {
+    return true;
 }
 
-void FakeSetupManager::switchHVPMTON(std::size_t id) {
+bool FakeSetupManager::switchHVPMTON(std::size_t id) {
+    return true;
 }
 
-void FakeSetupManager::switchHVPMTOFF(std::size_t id) {
+bool FakeSetupManager::switchHVPMTOFF(std::size_t id) {
+    return true;
 }
 
 

--- a/src/HVGroup.cpp
+++ b/src/HVGroup.cpp
@@ -1,5 +1,8 @@
 #include <QString>
 
+#include <memory>
+#include <cstddef>
+
 #include "HVGroup.h"
 #include "Interface.h"
 
@@ -11,39 +14,48 @@ HVGroup::HVGroup(Interface& m_interface):
 
         m_layout = new QGridLayout();
 
-        int temp_iterator = 0;
-        for (int setHVValue : m_interface.getConditions().getHVPMTSetValues()) {
+        for (int hv_id = 0; hv_id < m_interface.getConditions().getNHVPMT(); hv_id++) {
+            int setHVValue = m_interface.m_conditions->getHVPMTSetValue(hv_id);
+            
             HVEntry hventry;
-            const QString label = "HV " + QString::number(temp_iterator) + " value:";
+            
+            const QString label = "HV " + QString::number(hv_id) + " value:";
             hventry.label = new QLabel(label);
+            
             hventry.spin_box = new QSpinBox();
             hventry.spin_box->setRange(0, 2000);
             hventry.spin_box->setWrapping(1);
             hventry.spin_box->setSingleStep(1);
             hventry.spin_box->setValue(setHVValue);
+            
             hventry.value_label = new QLabel(std::to_string(hventry.spin_box->value()).c_str());
             hventry.value_label->hide();
+            
             //connect(hventry.spin_box, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &HVGroup::valueChanged);
+            
             m_hventries.push_back(hventry);
-            m_layout->addWidget(hventry.label, temp_iterator, 0);
-            m_layout->addWidget(hventry.spin_box, temp_iterator, 1);
-            m_layout->addWidget(hventry.value_label, temp_iterator, 1);
-            temp_iterator++;
+            
+            m_layout->addWidget(hventry.label, hv_id, 0);
+            m_layout->addWidget(hventry.spin_box, hv_id, 1);
+            m_layout->addWidget(hventry.value_label, hv_id, 1);
         }
 
         m_on_btn = new QPushButton("Switch On");
         //connect(m_on_btn, &QPushButton::clicked, [&](){ m_interface.getSetupManager()->switchHVPMTON(); });
         connect(m_on_btn, &QPushButton::clicked, this, &HVGroup::switchON);
-        m_layout->addWidget(m_on_btn, temp_iterator, 0);
+        connect(m_on_btn, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
+        m_layout->addWidget(m_on_btn, m_interface.m_conditions->getNHVPMT(), 0);
 
         m_off_btn = new QPushButton("Switch OFF");
         connect(m_off_btn, &QPushButton::clicked, this, &HVGroup::switchOFF);
-        m_layout->addWidget(m_off_btn, temp_iterator, 0);
+        connect(m_off_btn, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
+        m_layout->addWidget(m_off_btn, m_interface.m_conditions->getNHVPMT(), 0);
         m_off_btn->hide();
 
         m_set = new QPushButton("Set");
         connect(m_set, &QPushButton::clicked, this, &HVGroup::setHV);
-        m_layout->addWidget(m_set, temp_iterator, 1);
+        connect(m_set, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
+        m_layout->addWidget(m_set, m_interface.m_conditions->getNHVPMT(), 1);
         m_box->setLayout(m_layout);
 
 }
@@ -56,30 +68,42 @@ HVGroup::HVGroup(Interface& m_interface):
 //}
 
 void HVGroup::switchON() {
-    m_interface.getSetupManager()->switchHVPMTON();
-    m_on_btn->hide();
-    m_off_btn->show();
+    //m_interface.getSetupManager()->switchHVPMTON();
+    
+    // Update Condition manager with new HV states
+    for (std::size_t id = 0; id < m_hventries.size(); id++) {
+        m_interface.m_conditions->setHVPMTState(id, 1);
+    }
+    
+    //m_on_btn->hide();
+    //m_off_btn->show();
 }
 
 void HVGroup::switchOFF() {
-    m_interface.getSetupManager()->switchHVPMTOFF();
-    m_off_btn->hide();
-    m_on_btn->show();
+    //m_interface.getSetupManager()->switchHVPMTOFF();
+    
+    // Update Condition manager with new HV states
+    for (std::size_t id = 0; id < m_hventries.size(); id++) {
+        m_interface.m_conditions->setHVPMTState(id, 0);
+    }
+    
+    //m_off_btn->hide();
+    //m_on_btn->show();
 }
 
 void HVGroup::setHV() {
     // Update Condition manager with new HV set values
-    for (size_t id = 0; id < m_hventries.size(); id++) {
+    for (std::size_t id = 0; id < m_hventries.size(); id++) {
         HVEntry hventry = m_hventries.at(id);
         hventry.value_label = new QLabel(QString::number(hventry.spin_box->value()));
-        m_interface.getConditions().setHVPMTValue(id, hventry.spin_box->value());
+        m_interface.m_conditions->setHVPMTValue(id, hventry.spin_box->value());
     }
     // Set physically the HV values
-    m_interface.getSetupManager()->setHVPMT();
+    //m_interface.getSetupManager()->setHVPMT();
 }
 
 void HVGroup::setRunning() {
-    for (HVEntry hventry : m_hventries) {
+    for (HVEntry hventry: m_hventries) {
         hventry.spin_box->hide();
         hventry.value_label->show();
     }
@@ -87,7 +111,7 @@ void HVGroup::setRunning() {
 }
 
 void HVGroup::setNotRunning() {
-    for (HVEntry hventry : m_hventries) {
+    for (HVEntry hventry: m_hventries) {
         hventry.spin_box->show();
         hventry.value_label->hide();
     }

--- a/src/HVGroup.cpp
+++ b/src/HVGroup.cpp
@@ -5,6 +5,7 @@
 
 #include "HVGroup.h"
 #include "Interface.h"
+#include "ConditionManager.h"
 
 HVGroup::HVGroup(Interface& m_interface):
     m_interface(m_interface),

--- a/src/HVGroup.cpp
+++ b/src/HVGroup.cpp
@@ -30,7 +30,7 @@ HVGroup::HVGroup(Interface& m_interface):
             hventry.spin_box->setSingleStep(1);
             hventry.spin_box->setValue(setHVValue);
             
-            hventry.value_label = new QLabel(std::to_string(hventry.spin_box->value()).c_str());
+            hventry.value_label = new QLabel(QString::number(hventry.spin_box->value()));
             hventry.value_label->hide();
             
             //connect(hventry.spin_box, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &HVGroup::valueChanged);
@@ -105,8 +105,8 @@ void HVGroup::setHV() {
     // Update Condition manager with new HV set values
     for (std::size_t id = 0; id < m_hventries.size(); id++) {
         HVEntry hventry = m_hventries.at(id);
-        hventry.value_label = new QLabel(QString::number(hventry.spin_box->value()));
-        m_interface.m_conditions->setHVPMTValue(id, hventry.spin_box->value());
+        int new_value = m_interface.m_conditions->setHVPMTValue(id, hventry.spin_box->value());
+        hventry.value_label->setText(QString::number(new_value));
     }
 }
 

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -7,28 +7,14 @@
 #include <QGroupBox>
 
 #include "Interface.h"
-#include "SetupManager.h"
-#include "RealSetupManager.h"
-#include "FakeSetupManager.h"
-#include "VmeUsbBridge.h"
+#include "LoggingManager.h"
+#include "ConditionManager.h"
+#include "HVGroup.h"
 
 Interface::Interface(QWidget *parent): 
     QWidget(parent),
     m_conditions(new ConditionManager(*this)),
     running(false) {
-
-        std::cout << "Checking if the PC is connected to board..." << std::endl;
-        UsbController *dummy_controller = new UsbController(DEBUG);
-        bool canTalkToBoards = (dummy_controller->getStatus() == 0);
-        std::cout << "Deleting dummy USB controller..." << std::endl;
-        delete dummy_controller;
-        if (canTalkToBoards) {
-            std::cout << "You are on 'the' machine connected to the boards and can take action on them." << std::endl;
-            m_setup_manager = std::make_shared<RealSetupManager>(*this);
-        } else {
-            std::cout << "WARNING : You are not on 'the' machine connected to the boards. Actions on the setup will be ignored." << std::endl;
-            m_setup_manager = std::make_shared<FakeSetupManager>();
-        }
 
         std::cout << "Creating Interface. Qt version: " << qVersion() << "." << std::endl;
         QGridLayout *master_grid = new QGridLayout();

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -3,9 +3,8 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QGridLayout>
+#include <QVBoxLayout>
 #include <QGroupBox>
-
-#include <mutex>
 
 #include "Interface.h"
 #include "SetupManager.h"
@@ -15,7 +14,6 @@
 
 Interface::Interface(QWidget *parent): 
     QWidget(parent),
-    label(nullptr),
     m_conditions(new ConditionManager()),
     running(false) {
 
@@ -26,35 +24,28 @@ Interface::Interface(QWidget *parent):
         delete dummy_controller;
         if (canTalkToBoards) {
             std::cout << "You are on 'the' machine connected to the boards and can take action on them." << std::endl;
-            m_setup_manager = new RealSetupManager(*this);
-        }
-        else {
+            m_setup_manager = std::make_shared<RealSetupManager>(*this);
+        } else {
             std::cout << "WARNING : You are not on 'the' machine connected to the boards. Actions on the setup will be ignored." << std::endl;
-            m_setup_manager = new FakeSetupManager();
+            m_setup_manager = std::make_shared<FakeSetupManager>();
         }
 
         std::cout << "Creating Interface. Qt version: " << qVersion() << "." << std::endl;
         QGridLayout *master_grid = new QGridLayout();
 
         QGroupBox *run_box = new QGroupBox("Run control");
-        QGridLayout *run_grid = new QGridLayout();
+        QVBoxLayout *run_layout = new QVBoxLayout();
         
         QPushButton *startBtn = new QPushButton("Start");
         QPushButton *stopBtn = new QPushButton("Stop");
-        QPushButton *plsBtn = new QPushButton("+ 100");
-        QPushButton *minBtn = new QPushButton("- 100");
-        label = new QLabel("0");
         QPushButton *quit = new QPushButton("Quit");
         
         m_hv_group = new HVGroup(*this);
 
-        run_grid->addWidget(startBtn, 0, 0);
-        run_grid->addWidget(stopBtn, 0, 1);
-        run_grid->addWidget(plsBtn, 1, 0);
-        run_grid->addWidget(minBtn, 1, 1);
-        run_grid->addWidget(quit, 2, 0);
-        run_grid->addWidget(label, 2, 1);
-        run_box->setLayout(run_grid);
+        run_layout->addWidget(startBtn);
+        run_layout->addWidget(stopBtn);
+        run_layout->addWidget(quit);
+        run_box->setLayout(run_layout);
 
         master_grid->addWidget(run_box, 0, 0);
         master_grid->addWidget(m_hv_group, 0, 1);
@@ -63,8 +54,6 @@ Interface::Interface(QWidget *parent):
 
         connect(startBtn, &QPushButton::clicked, this, &Interface::startLoggingManager);
         connect(stopBtn, &QPushButton::clicked, this, &Interface::stopLoggingManager);
-        connect(plsBtn, &QPushButton::clicked, this, &Interface::onPlus);
-        connect(minBtn, &QPushButton::clicked, this, &Interface::onMinus);
         connect(quit, &QPushButton::clicked, this, &Interface::stopLoggingManager);
         connect(quit, &QPushButton::clicked, [=](){ m_setup_manager->switchHVPMTOFF(); });
         connect(quit, &QPushButton::clicked, qApp, &QApplication::quit);
@@ -78,11 +67,6 @@ ConditionManager& Interface::getConditions() {
 }
 
 void Interface::notifyUpdate() {
-    setCounter(m_conditions->getCounter());
-}
-
-void Interface::setCounter(int i) {
-    label->setText(QString::number(i));
 }
 
 void Interface::startLoggingManager() {
@@ -105,24 +89,9 @@ void Interface::stopLoggingManager() {
     thread_handler.join();
     m_logging_manager.reset();
 
-    m_conditions->setCounter(0);
     notifyUpdate();
 
     m_hv_group->setNotRunning();
 
     running = false;
-}
-
-void Interface::onPlus() {
-    std::lock_guard<std::mutex> lock(m_conditions->getLock());
-    int val = m_conditions->getCounter() + 100;
-    label->setText(QString::number(val));
-    m_conditions->setCounter(val);
-}
-
-void Interface::onMinus() {
-    std::lock_guard<std::mutex> lock(m_conditions->getLock());
-    int val = m_conditions->getCounter() - 100;
-    label->setText(QString::number(val));
-    m_conditions->setCounter(val);
 }

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -5,6 +5,7 @@
 #include <QGridLayout>
 #include <QVBoxLayout>
 #include <QGroupBox>
+#include <QTimer>
 
 #include "Interface.h"
 #include "LoggingManager.h"
@@ -43,8 +44,11 @@ Interface::Interface(QWidget *parent):
         connect(quit, &QPushButton::clicked, this, &Interface::stopLoggingManager);
         connect(quit, &QPushButton::clicked, qApp, &QApplication::quit);
 
-        resize(500, 200);
-        //showFullScreen();
+        resize(800, 600);
+        
+        m_timer = new QTimer(this);
+        connect(m_timer, &QTimer::timeout, this, &Interface::notifyUpdate);
+        m_timer->start(250);
     }
 
 ConditionManager& Interface::getConditions() {
@@ -52,6 +56,7 @@ ConditionManager& Interface::getConditions() {
 }
 
 void Interface::notifyUpdate() {
+    m_hv_group->notifyUpdate();
 }
 
 void Interface::updateConditionLog() {

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -14,7 +14,7 @@
 
 Interface::Interface(QWidget *parent): 
     QWidget(parent),
-    m_conditions(new ConditionManager()),
+    m_conditions(new ConditionManager(*this)),
     running(false) {
 
         std::cout << "Checking if the PC is connected to board..." << std::endl;
@@ -55,7 +55,6 @@ Interface::Interface(QWidget *parent):
         connect(startBtn, &QPushButton::clicked, this, &Interface::startLoggingManager);
         connect(stopBtn, &QPushButton::clicked, this, &Interface::stopLoggingManager);
         connect(quit, &QPushButton::clicked, this, &Interface::stopLoggingManager);
-        connect(quit, &QPushButton::clicked, [=](){ m_setup_manager->switchHVPMTOFF(); });
         connect(quit, &QPushButton::clicked, qApp, &QApplication::quit);
 
         resize(500, 200);
@@ -67,6 +66,11 @@ ConditionManager& Interface::getConditions() {
 }
 
 void Interface::notifyUpdate() {
+}
+
+void Interface::updateConditionLog() {
+    if (running)
+        m_logging_manager->updateConditionManagerLog();
 }
 
 void Interface::startLoggingManager() {

--- a/src/LoggingManager.cpp
+++ b/src/LoggingManager.cpp
@@ -7,6 +7,7 @@
 #include <json/writer.h>
 
 #include "LoggingManager.h"
+#include "ConditionManager.h"
 #include "Interface.h"
 #include "Utils.h"
 

--- a/src/LoggingManager.cpp
+++ b/src/LoggingManager.cpp
@@ -72,7 +72,6 @@ void LoggingManager::initContinuousLog() {
 }
     
 void LoggingManager::updateContinuousLog(m_clock::time_point log_time) {
-    int counter = m_conditions.getCounter();
     std::vector<int> hv = m_conditions.getHVPMTSetValues();
     m_continuous_log << log_time.time_since_epoch().count() << "," << hv[0] << std::endl;
     std::cout << timeToString<m_clock>(log_time) << " -- HV = " << hv[0] << std::endl;

--- a/src/RealSetupManager.cpp
+++ b/src/RealSetupManager.cpp
@@ -6,6 +6,7 @@
 
 #include "RealSetupManager.h"
 #include "Interface.h"
+#include "ConditionManager.h"
 
 RealSetupManager::RealSetupManager(Interface& m_interface):
     m_interface(m_interface),

--- a/src/RealSetupManager.cpp
+++ b/src/RealSetupManager.cpp
@@ -20,24 +20,21 @@ RealSetupManager::~RealSetupManager() {
     }
 }
 
-void RealSetupManager::setHVPMT(std::size_t id) {
+bool RealSetupManager::setHVPMT(std::size_t id) {
     std::cout << "Setting the HV PMT..." << std::endl;
     
     int set_hv_value = m_interface.getConditions().getHVPMTSetValue(id);
-    m_hvpmt.setChV(set_hv_value, id);
-    std::cout << "  HV " << id << " set to " << set_hv_value << " volts." << std::endl;
+    return m_hvpmt.setChV(set_hv_value, id) == 1;
 }
 
-void RealSetupManager::switchHVPMTON(std::size_t id) {
+bool RealSetupManager::switchHVPMTON(std::size_t id) {
     std::cout << "Switching the HV PMT ON..." << std::endl;
     
-    m_hvpmt.setChState(1, id);
-    std::cout << "  HV " << id << " switched to state 1." <<  std::endl;
+    return m_hvpmt.setChState(1, id) == 1;
 }
 
-void RealSetupManager::switchHVPMTOFF(std::size_t id) {
+bool RealSetupManager::switchHVPMTOFF(std::size_t id) {
     std::cout << "Switching the HV PMT OFF..." << std::endl;
     
-    m_hvpmt.setChState(0, id);
-    std::cout << "  HV " << id << " switched to state 0." <<  std::endl;
+    return m_hvpmt.setChState(0, id) == 1;
 }

--- a/src/RealSetupManager.cpp
+++ b/src/RealSetupManager.cpp
@@ -1,3 +1,9 @@
+#include <cstddef>
+#include <iostream>
+
+#include "VmeUsbBridge.h"
+#include "HV.h"
+
 #include "RealSetupManager.h"
 #include "Interface.h"
 
@@ -7,32 +13,30 @@ RealSetupManager::RealSetupManager(Interface& m_interface):
     m_hvpmt(hv(&m_controller, 0xF0000, 2)) 
     { }
 
-void RealSetupManager::setHVPMT() {
-    std::vector<int> hvpmt_setValues = m_interface.getConditions().getHVPMTSetValues();
+RealSetupManager::~RealSetupManager() {
+    for (std::size_t id = 0; id < m_interface.getConditions().getNHVPMT(); id++) {
+        m_hvpmt.setChState(0, id);
+    }
+}
+
+void RealSetupManager::setHVPMT(std::size_t id) {
     std::cout << "Setting the HV PMT..." << std::endl;
-    for (int entry = 0; entry < hvpmt_setValues.size(); entry++){
-        m_hvpmt.setChV(hvpmt_setValues.at(entry), entry);
-        std::cout << "  HV " << entry << " set to " << hvpmt_setValues.at(entry) << " volts." << std::endl;
-    }
-    std::cout << "Done!" << std::endl;
+    
+    int set_hv_value = m_interface.getConditions().getHVPMTSetValue(id);
+    m_hvpmt.setChV(set_hv_value, id);
+    std::cout << "  HV " << id << " set to " << set_hv_value << " volts." << std::endl;
 }
 
-void RealSetupManager::switchHVPMTON() {
+void RealSetupManager::switchHVPMTON(std::size_t id) {
     std::cout << "Switching the HV PMT ON..." << std::endl;
-    std::vector<int> hvpmt_state = m_interface.getConditions().getHVPMTSetStates();
-    for (int entry = 0; entry < hvpmt_state.size(); entry++){
-        m_hvpmt.setChState(hvpmt_state.at(entry), entry);
-        std::cout << "  HV " << entry << " switched to state " << hvpmt_state.at(entry) << "." <<  std::endl;
-    }
-    std::cout << "Done!" << std::endl;
+    
+    m_hvpmt.setChState(1, id);
+    std::cout << "  HV " << id << " switched to state 1." <<  std::endl;
 }
 
-void RealSetupManager::switchHVPMTOFF() {
+void RealSetupManager::switchHVPMTOFF(std::size_t id) {
     std::cout << "Switching the HV PMT OFF..." << std::endl;
-    std::vector<int> hvpmt_state = m_interface.getConditions().getHVPMTSetStates();
-    for (int entry = 0; entry < hvpmt_state.size(); entry++){
-        m_hvpmt.setChState(0, entry);
-        std::cout << "  HV " << entry << " switched to state 0." <<  std::endl;
-    }
-    std::cout << "Done!" << std::endl;
+    
+    m_hvpmt.setChState(0, id);
+    std::cout << "  HV " << id << " switched to state 0." <<  std::endl;
 }


### PR DESCRIPTION
- Changes in Martin library: cosmetic changes only
- Logging the HV values now works, I've added a small "CSV" class to ease continuous logging in csv file
- As discussed, calling the SetupManager now is done exclusively by the ConditionManager, the interface doesn't interact with the hardware directly
- I've moved the job of creating the SetupManager to the ConditionManager (makes sense given the above), otherwise there was a problem with the order in which things are deleted
- Switching off the HVs is done in the destructor of ConditionManager, not from the interface "quit"
- The interface is not refreshed periodically by the LoggingManager anymore, but using a QTimer instance

The tricky things still to be discussed are here:
https://github.com/swertz/SlowControlTBL/compare/nextStep?expand=1#diff-93690aeb14afa889b2346ae3014dfb7cR70
https://github.com/swertz/SlowControlTBL/compare/nextStep?expand=1#diff-50e0191207835917aa036e8611e5477eR33
https://github.com/swertz/SlowControlTBL/compare/nextStep?expand=1#diff-2f7050afddb2a53a1bf42549e9888a4bR75
https://github.com/swertz/SlowControlTBL/compare/nextStep?expand=1#diff-93690aeb14afa889b2346ae3014dfb7cR108
