### PR TITLE
Push HV GUI further

### DIFF
--- a/CosmicTrigger/include/HV.cpp
+++ b/CosmicTrigger/include/HV.cpp
@@ -122,7 +122,7 @@ int hv::setChV(int volt, int channel){
 
 double ** hv::readValues(double ** val){
   if(val==0){
-    cout<<"New value vector"<<endl;
+    //cout<<"New value vector"<<endl;
     val=new double * [4]; 
     for(int i=0; i<4; i++) val[i]=new double[4];
   }

--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -25,10 +25,10 @@ class ConditionManager {
             m_interface(m_interface),
             m_state(State::idle),
             m_hvpmt({
-                    { 1025, 1025, false, 0, 0, false },
-                    { 925, 925, false, 0, 0, false },
-                    { 1225, 1225, false, 0, 0, false },
-                    { 0, 0, false, 0, 0, false }
+                    { 1025, 0, 0, false, true, false },
+                    { 925, 0, 0, false, true, false },
+                    { 1225, 0, 0, false, true, false },
+                    { 0, 0, 0, false, false, false }
                     })
         {
             std::cout << "Checking if the PC is connected to board..." << std::endl;
@@ -41,7 +41,7 @@ class ConditionManager {
                 m_setup_manager = std::make_shared<RealSetupManager>(m_interface);
             } else {
                 std::cout << "WARNING : You are not on 'the' machine connected to the boards. Actions on the setup will be ignored." << std::endl;
-                m_setup_manager = std::make_shared<FakeSetupManager>();
+                m_setup_manager = std::make_shared<FakeSetupManager>(m_interface);
             }
 
             // for testing purposes
@@ -73,9 +73,10 @@ class ConditionManager {
         struct HVPMT {
             int setValue;
             int readValue;
+            int readCurrent;
             bool valueChanged;
-            int setState;
-            int readState;
+            bool setState;
+            //int readState;
             bool stateChanged;
         };
 
@@ -107,15 +108,18 @@ class ConditionManager {
         std::mutex& getTDCLock() { return m_tdc_mtx; }
 
         /*
-         * Define/retrieve the PMT HV value (no action taken on the setup)
+         * Define/retrieve/propagate the PMT HV conditions
          * So far, this is a vector with entry==channel
          */
-        int setHVPMTValue(std::size_t id, int value);
-        bool setHVPMTState(std::size_t id, int state);
+        void setHVPMTValue(std::size_t id, int value) { m_hvpmt.at(id).setValue = value; }
+        void setHVPMTState(std::size_t id, bool state) { m_hvpmt.at(id).setState = state; }
+        bool propagateHVPMTValue(std::size_t id);
+        bool propagateHVPMTState(std::size_t id);
         int getHVPMTSetValue(std::size_t id) const { return m_hvpmt.at(id).setValue; }
         int getHVPMTReadValue(std::size_t id) const { return m_hvpmt.at(id).readValue; }
-        int getHVPMTSetState(std::size_t id) const { return m_hvpmt.at(id).setState; }
-        int getHVPMTReadState(std::size_t id) const { return m_hvpmt.at(id).readState; }
+        int getHVPMTReadCurrent(std::size_t id) const { return m_hvpmt.at(id).readCurrent; }
+        bool getHVPMTSetState(std::size_t id) const { return m_hvpmt.at(id).setState; }
+        //int getHVPMTReadState(std::size_t id) const { return m_hvpmt.at(id).readState; }
         std::size_t getNHVPMT() const { return m_hvpmt.size(); }
 
         /*

--- a/include/FakeSetupManager.h
+++ b/include/FakeSetupManager.h
@@ -1,16 +1,26 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 #include "SetupManager.h"
+
+class Interface;
 
 class FakeSetupManager: public SetupManager {
     
     public:
+
+        FakeSetupManager(Interface& m_interface);
 
         virtual ~FakeSetupManager() override {};
 
         virtual bool setHVPMT(std::size_t id) override;
         virtual bool switchHVPMTON(std::size_t id) override;
         virtual bool switchHVPMTOFF(std::size_t id) override;
+        virtual std::vector< std::pair<double, double> > getHVPMTValue() override;
+
+    private:
+
+        Interface& m_interface;
 };

--- a/include/HVGroup.h
+++ b/include/HVGroup.h
@@ -7,6 +7,7 @@
 #include <QSpinBox>
 #include <QGridLayout>
 #include <QPushButton>
+#include <QCheckBox>
 
 #include <memory>
 #include <cstddef>
@@ -24,15 +25,17 @@ class HVGroup : public QWidget {
         
         struct HVEntry {
             QLabel *label;
-            QLabel *value_label;
-            QSpinBox *spin_box;
+            QLabel *setValue_label;
+            QLabel *readValue_label;
+            QLabel *readCurrent_label;
+            QSpinBox *sb_set_value;
+            QCheckBox *cb_set_state;
         };
 
     public:
         void notifyUpdate();
 
     private slots:
-        //void valueChanged(int m_hv);
         void setRunning();
         void setNotRunning();
         void switchON();

--- a/include/RealSetupManager.h
+++ b/include/RealSetupManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 #include "SetupManager.h"
 #include "VmeUsbBridge.h"
@@ -21,6 +22,8 @@ class RealSetupManager: public SetupManager {
         virtual bool setHVPMT(size_t id) override;
         virtual bool switchHVPMTON(size_t id) override;
         virtual bool switchHVPMTOFF(size_t id) override;
+        virtual std::vector< std::pair<double, double> > getHVPMTValue() override;
+        //virtual int getHVPMTState(size_t id) override;
 
     private:
 

--- a/include/SetupManager.h
+++ b/include/SetupManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 class SetupManager {
     public:
@@ -9,4 +10,5 @@ class SetupManager {
         virtual bool setHVPMT(std::size_t id) = 0;
         virtual bool switchHVPMTON(std::size_t id) = 0;
         virtual bool switchHVPMTOFF(std::size_t id) = 0;
+        virtual std::vector< std::pair<double, double> > getHVPMTValue() = 0;
 };

--- a/src/FakeSetupManager.cpp
+++ b/src/FakeSetupManager.cpp
@@ -1,6 +1,12 @@
 #include "FakeSetupManager.h"
+#include "Interface.h"
+#include "ConditionManager.h"
 
 #include <cstddef>
+
+FakeSetupManager::FakeSetupManager(Interface& m_interface):
+    m_interface(m_interface)
+    { }
 
 bool FakeSetupManager::setHVPMT(std::size_t id) {
     return true;
@@ -14,4 +20,10 @@ bool FakeSetupManager::switchHVPMTOFF(std::size_t id) {
     return true;
 }
 
-
+std::vector< std::pair<double, double> > FakeSetupManager::getHVPMTValue() {
+    std::vector< std::pair<double, double> > hv_values;
+    for (std::size_t id = 0; id < m_interface.getConditions().getNHVPMT(); id++) {
+        hv_values.push_back(std::make_pair(0., 0.));
+    }
+    return hv_values;
+}

--- a/src/HVGroup.cpp
+++ b/src/HVGroup.cpp
@@ -16,78 +16,124 @@ HVGroup::HVGroup(Interface& m_interface):
 
         m_layout = new QGridLayout();
 
+        QLabel *toplabel_set_value = new QLabel("Set voltage");
+        toplabel_set_value->setAlignment(Qt::AlignCenter);
+        int position_set_value = 1;
+        m_layout->addWidget(toplabel_set_value, 0, position_set_value);
+
+        QLabel *toplabel_read_value = new QLabel("Read voltage");
+        toplabel_read_value->setAlignment(Qt::AlignCenter);
+        int position_read_value = 2;
+        m_layout->addWidget(toplabel_read_value, 0, position_read_value);
+
+        QLabel *toplabel_read_current = new QLabel("Read current");
+        toplabel_read_current->setAlignment(Qt::AlignCenter);
+        int position_read_current = 3;
+        m_layout->addWidget(toplabel_read_current, 0, position_read_current);
+
+        QLabel *toplabel_set_state = new QLabel("Switch ON");
+        toplabel_set_state->setAlignment(Qt::AlignCenter);
+        int position_set_state = 4;
+        m_layout->addWidget(toplabel_set_state, 0, position_set_state);
+
+        //m_layout->addWidget(toplabel_read_state, 0, 4);
+
         for (int hv_id = 0; hv_id < m_interface.m_conditions->getNHVPMT(); hv_id++) {
+
             int setHVValue = m_interface.m_conditions->getHVPMTSetValue(hv_id);
             
             HVEntry hventry;
             
-            const QString label = "HV " + QString::number(hv_id) + " value:";
+            const QString label = "HV " + QString::number(hv_id) + " :";
             hventry.label = new QLabel(label);
+
+            hventry.cb_set_state = new QCheckBox();
+            hventry.cb_set_state->setStyleSheet("margin-left:50%; margin-right:50%;");
+            hventry.cb_set_state->setChecked(m_interface.m_conditions->getHVPMTSetState(hv_id));
+            //connect(hventry.cb_set_state, &QCheckBox::stateChanged, [&](){ m_interface.m_conditions->setHVPMTState(hventry.hv_number, hventry.cb_set_state->isChecked());});
             
-            hventry.spin_box = new QSpinBox();
-            hventry.spin_box->setRange(0, 2000);
-            hventry.spin_box->setWrapping(1);
-            hventry.spin_box->setSingleStep(1);
-            hventry.spin_box->setValue(setHVValue);
+            hventry.sb_set_value = new QSpinBox();
+            hventry.sb_set_value->setRange(0, 2000);
+            hventry.sb_set_value->setWrapping(1);
+            hventry.sb_set_value->setSingleStep(1);
+            hventry.sb_set_value->setValue(setHVValue);
             
-            hventry.value_label = new QLabel(QString::number(hventry.spin_box->value()));
-            hventry.value_label->hide();
-            
-            //connect(hventry.spin_box, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &HVGroup::valueChanged);
+            hventry.setValue_label = new QLabel(QString::number(hventry.sb_set_value->value()));
+            hventry.setValue_label->hide();
+
+            hventry.readValue_label = new QLabel(QString::number(m_interface.m_conditions->getHVPMTReadValue(hv_id)));
+            hventry.readValue_label->setAlignment(Qt::AlignCenter);
+            hventry.readValue_label->setStyleSheet("QLabel { background-color : red; }");
+
+            hventry.readCurrent_label = new QLabel(QString::number(m_interface.m_conditions->getHVPMTReadCurrent(hv_id)));
+            hventry.readCurrent_label->setAlignment(Qt::AlignCenter);
             
             m_hventries.push_back(hventry);
-            
-            m_layout->addWidget(hventry.label, hv_id, 0);
-            m_layout->addWidget(hventry.spin_box, hv_id, 1);
-            m_layout->addWidget(hventry.value_label, hv_id, 1);
+
+            const int position = hv_id+1;            
+            m_layout->addWidget(hventry.label, position, 0);
+            m_layout->addWidget(hventry.cb_set_state, position, position_set_state);
+            m_layout->addWidget(hventry.sb_set_value, position, position_set_value);
+            m_layout->addWidget(hventry.setValue_label, position, position_set_value);
+            m_layout->addWidget(hventry.readValue_label, position, position_read_value);
+            m_layout->addWidget(hventry.readCurrent_label, position, position_read_current);
         }
 
-        m_on_btn = new QPushButton("Switch On");
+        m_on_btn = new QPushButton("Propagate");
         //connect(m_on_btn, &QPushButton::clicked, [&](){ m_interface.getSetupManager()->switchHVPMTON(); });
         connect(m_on_btn, &QPushButton::clicked, this, &HVGroup::switchON);
         connect(m_on_btn, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
-        m_layout->addWidget(m_on_btn, m_interface.m_conditions->getNHVPMT(), 0);
+        m_layout->addWidget(m_on_btn, m_interface.m_conditions->getNHVPMT()+1, position_set_state);
 
         m_off_btn = new QPushButton("Switch OFF");
         connect(m_off_btn, &QPushButton::clicked, this, &HVGroup::switchOFF);
         connect(m_off_btn, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
-        m_layout->addWidget(m_off_btn, m_interface.m_conditions->getNHVPMT(), 0);
+        m_layout->addWidget(m_off_btn, m_interface.m_conditions->getNHVPMT()+1, position_set_state);
         m_off_btn->hide();
 
         m_set = new QPushButton("Set");
         connect(m_set, &QPushButton::clicked, this, &HVGroup::setHV);
         connect(m_set, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
-        m_layout->addWidget(m_set, m_interface.m_conditions->getNHVPMT(), 1);
+        m_layout->addWidget(m_set, m_interface.m_conditions->getNHVPMT()+1, position_set_value);
         m_box->setLayout(m_layout);
 
 }
 
-//void HVGroup::valueChanged(int m_hv) {
-//    if(m_interface.isRunning()) {
-//        //m_spin_hv0->setValue(m_interface.getConditions().getHVPMTSetValues()[0]);
-//        return;
-//    }
-//}
-
 void HVGroup::notifyUpdate() {
     std::lock_guard<std::mutex> m_lock(m_interface.m_conditions->getHVLock());
 
-    if (m_interface.m_conditions->getHVPMTReadState(0)) {
-        m_on_btn->hide();
-        m_off_btn->show();
-    } else {
-        m_off_btn->hide();
-        m_on_btn->show();
+    //if (m_interface.m_conditions->getHVPMTReadState(0)) {
+    //    m_on_btn->hide();
+    //    m_off_btn->show();
+    //} else {
+    //    m_off_btn->hide();
+    //    m_on_btn->show();
+    //}
+    for (int hv_id = 0; hv_id < m_interface.m_conditions->getNHVPMT(); hv_id++) {
+        if (std::abs(m_interface.m_conditions->getHVPMTReadValue(hv_id) - m_interface.m_conditions->getHVPMTSetValue(hv_id))/float(m_interface.m_conditions->getHVPMTSetValue(hv_id)) > 0.05) {
+            m_hventries.at(hv_id).readValue_label->setStyleSheet("QLabel { background-color : red; }");
+        }
+        else {
+            m_hventries.at(hv_id).readValue_label->setStyleSheet("QLabel { background-color : green; }");
+        }
+        m_hventries.at(hv_id).readValue_label->setText(QString::number(m_interface.m_conditions->getHVPMTReadValue(hv_id)));
+        m_hventries.at(hv_id).readCurrent_label->setText(QString::number(m_interface.m_conditions->getHVPMTReadCurrent(hv_id)));
     }
+
 }
 
 void HVGroup::switchON() {
     std::lock_guard<std::mutex> m_lock(m_interface.m_conditions->getHVLock());
 
-    // Update Condition manager with new HV states
+    // Propagate the new states to the Condition manager
+    // Condition manager will tell setup manager to actually set the right state
     for (std::size_t id = 0; id < m_hventries.size(); id++) {
-        m_interface.m_conditions->setHVPMTState(id, 1);
+        bool state = m_hventries.at(id).cb_set_state->isChecked();
+        m_interface.m_conditions->setHVPMTState(id, state);
+        m_interface.m_conditions->propagateHVPMTState(id);
     }
+    m_on_btn->hide();
+    m_off_btn->show();
 }
 
 void HVGroup::switchOFF() {
@@ -96,7 +142,10 @@ void HVGroup::switchOFF() {
     // Update Condition manager with new HV states
     for (std::size_t id = 0; id < m_hventries.size(); id++) {
         m_interface.m_conditions->setHVPMTState(id, 0);
+        m_interface.m_conditions->propagateHVPMTState(id);
     }
+    m_on_btn->show();
+    m_off_btn->hide();
 }
 
 void HVGroup::setHV() {
@@ -105,23 +154,24 @@ void HVGroup::setHV() {
     // Update Condition manager with new HV set values
     for (std::size_t id = 0; id < m_hventries.size(); id++) {
         HVEntry hventry = m_hventries.at(id);
-        int new_value = m_interface.m_conditions->setHVPMTValue(id, hventry.spin_box->value());
-        hventry.value_label->setText(QString::number(new_value));
+        m_interface.m_conditions->setHVPMTValue(id, hventry.sb_set_value->value());
+        int new_value = m_interface.m_conditions->propagateHVPMTValue(id);
+        hventry.setValue_label->setText(QString::number(new_value));
     }
 }
 
 void HVGroup::setRunning() {
     for (HVEntry hventry: m_hventries) {
-        hventry.spin_box->hide();
-        hventry.value_label->show();
+        hventry.sb_set_value->hide();
+        hventry.setValue_label->show();
     }
     m_set->setDisabled(1);
 }
 
 void HVGroup::setNotRunning() {
     for (HVEntry hventry: m_hventries) {
-        hventry.spin_box->show();
-        hventry.value_label->hide();
+        hventry.sb_set_value->show();
+        hventry.setValue_label->hide();
     }
     m_set->setDisabled(0);
 }

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -44,7 +44,7 @@ Interface::Interface(QWidget *parent):
         connect(quit, &QPushButton::clicked, this, &Interface::stopLoggingManager);
         connect(quit, &QPushButton::clicked, qApp, &QApplication::quit);
 
-        resize(800, 600);
+        resize(1000, 300);
         
         m_timer = new QTimer(this);
         connect(m_timer, &QTimer::timeout, this, &Interface::notifyUpdate);

--- a/src/RealSetupManager.cpp
+++ b/src/RealSetupManager.cpp
@@ -20,21 +20,46 @@ RealSetupManager::~RealSetupManager() {
     }
 }
 
-bool RealSetupManager::setHVPMT(std::size_t id) {
-    std::cout << "Setting the HV PMT..." << std::endl;
-    
+bool RealSetupManager::setHVPMT(std::size_t id) { 
     int set_hv_value = m_interface.getConditions().getHVPMTSetValue(id);
+    std::cout << "Setting the HV PMT number " << id << " to " << set_hv_value << "." << std::endl;
+
     return m_hvpmt.setChV(set_hv_value, id) == 1;
 }
 
 bool RealSetupManager::switchHVPMTON(std::size_t id) {
-    std::cout << "Switching the HV PMT ON..." << std::endl;
+    std::cout << "Switching the HV PMT " << id << " ON..." << std::endl;
     
     return m_hvpmt.setChState(1, id) == 1;
 }
 
 bool RealSetupManager::switchHVPMTOFF(std::size_t id) {
-    std::cout << "Switching the HV PMT OFF..." << std::endl;
+    std::cout << "Switching the HV PMT " << id << " OFF..." << std::endl;
     
     return m_hvpmt.setChState(0, id) == 1;
 }
+
+std::vector< std::pair<double, double> > RealSetupManager::getHVPMTValue() {
+    // FIXME Maybe we could have a function reading value of only one PM
+    // Would require to modify Martin's library
+    std::vector< std::pair<double, double> > hv_values;
+    double ** temp_values = 0;
+    temp_values = m_hvpmt.readValues(temp_values);
+    for (std::size_t id = 0; id < m_interface.getConditions().getNHVPMT(); id++) {
+        hv_values.push_back(std::make_pair(temp_values[id][0], temp_values[id][1]));
+    }
+    return hv_values;
+}
+
+//std::vector<double> RealSetupManager::getHVPMTState() {
+//    // FIXME Not available yet in Martin's library
+//    // Probably not needed as the HV value tells everything
+//    std::vector<double> hv_values;
+//    double ** temp_values = 0;
+//    temp_values = m_hvpmt.readValues(temp_values);
+//    for (std::size_t id = 0; id < m_interface.getConditions().getNHVPMT(); id++) {
+//        std::cout << temp_values[id][0] << std::endl;
+//        hv_values.push_back(temp_values[id][0]);
+//    }
+//    return hv_values;
+//}


### PR DESCRIPTION
- Allow user to choose which HV to turn ON "on the flight"
- Display the actual HV value
- Make the box red if this value is different than the set one by more than 5% (helps notify shifter that the setup is not in the expected state)
- Display the PM "leakage" current

Code tested both with and without the possibility to talk to the set-up. Open for comments.

NB : choice was made to let all the freedom to the shifter (not freezing anything while we are running) which implies that shifters must be aware of what they do. Though, I left these functions in the code without calling them (in case we change our mind).
