### PR TITLE
Window pop-up to modify the discriminator settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/CosmicTrigger/include)
 
 set(LIBS ${LIBS} ${JSONCPP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_CURRENT_SOURCE_DIR}/CosmicTrigger/lib/libCAEN.so)
 
-qt5_wrap_cpp(Interfaces_SRC include/Interface.h include/HVGroup.h)
+qt5_wrap_cpp(Interfaces_SRC include/Interface.h include/HVGroup.h
+    include/DiscriSettingsWindow.h)
 
 set(SOURCES
     "src/main.cpp"
@@ -39,6 +40,7 @@ set(SOURCES
     "src/HVGroup.cpp"
     "src/RealSetupManager.cpp"
     "src/FakeSetupManager.cpp"
+    "src/DiscriSettingsWindow.cpp"
     ${Interfaces_SRC}
     )
 

--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -29,7 +29,15 @@ class ConditionManager {
                     { 925, 0, 0, false, true, false },
                     { 1225, 0, 0, false, true, false },
                     { 0, 0, 0, false, false, false }
-                    })
+                    }),
+            m_discriChannels({
+                    {true, 5, 200},
+                    {true, 5, 200},
+                    {true, 5, 200},
+                    {false, 5, 200},
+                    {false, 5, 200}
+                    }),
+            m_channelsMajority(3)
         {
             std::cout << "Checking if the PC is connected to board..." << std::endl;
             UsbController *dummy_controller = new UsbController(DEBUG);
@@ -80,6 +88,14 @@ class ConditionManager {
             bool stateChanged;
         };
 
+        // Discri settings
+        struct DiscriChannel {
+            bool included;
+            int threshold;
+            int width;
+        };
+
+
         /*
          * Get current ConditionManager state
          */
@@ -122,6 +138,17 @@ class ConditionManager {
         //int getHVPMTReadState(std::size_t id) const { return m_hvpmt.at(id).readState; }
         std::size_t getNHVPMT() const { return m_hvpmt.size(); }
 
+        void setDiscriChannelState(std::size_t id, bool state) { m_discriChannels.at(id).included = state; }
+        bool getDiscriChannelState(std::size_t id) const { return m_discriChannels.at(id).included; }
+        void setDiscriChannelThreshold(std::size_t id, int threshold) { m_discriChannels.at(id).threshold = threshold; }
+        int getDiscriChannelThreshold(std::size_t id) const { return m_discriChannels.at(id).threshold; }
+        void setDiscriChannelWidth(std::size_t id, int width) { m_discriChannels.at(id).width = width; }
+        int getDiscriChannelWidth(std::size_t id) const { return m_discriChannels.at(id).width; }
+        std::size_t getNDiscriChannels() const { return m_discriChannels.size(); }
+        int getChannelsMajority() const { return m_channelsMajority; }
+        void setChannelsMajority(int majority) { m_channelsMajority = majority; }
+        bool propagateDiscriSettings();
+
         /*
          * Daemons: will run as threads in the background,
          * handle the HV & TDC cards
@@ -147,6 +174,8 @@ class ConditionManager {
         std::thread thread_handle_TDC;
 
         std::vector<HVPMT> m_hvpmt;
+        std::vector<DiscriChannel> m_discriChannels;
+        int m_channelsMajority;
         
         std::shared_ptr<SetupManager> m_setup_manager;
 };

--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -31,11 +31,11 @@ class ConditionManager {
                     { 0, 0, 0, false, false, false }
                     }),
             m_discriChannels({
-                    {true, 5, 200},
-                    {true, 5, 200},
-                    {true, 5, 200},
-                    {false, 5, 200},
-                    {false, 5, 200}
+                    { true, 5, 200 },
+                    { true, 5, 200 },
+                    { true, 5, 200 },
+                    { false, 5, 200 },
+                    { false, 5, 200 }
                     }),
             m_channelsMajority(3)
         {

--- a/include/DiscriSettingsWindow.h
+++ b/include/DiscriSettingsWindow.h
@@ -1,0 +1,40 @@
+#include <QWidget>
+#include <QDialog>
+#include <QCheckBox>
+#include <QSpinBox>
+#include <QGroupBox>
+#include <QGridLayout>
+#include <QCloseEvent>
+#include <QLabel>
+
+#include <vector>
+
+class Interface;
+
+class DiscriSettingsWindow : public QDialog {
+    friend class Interface;
+
+    Q_OBJECT
+    
+    public:
+        DiscriSettingsWindow(Interface& m_interface);
+        void closeEvent(QCloseEvent *event);
+        struct DiscriChannel {
+            QLabel *label;
+            QCheckBox *included;
+            QSpinBox *threshold;
+            QSpinBox *width;
+        };
+
+    private slots:
+        void propagate();
+
+    private:
+        std::vector<DiscriChannel> m_discriChannels;
+        Interface& m_interface;
+        QGroupBox *m_box;
+        QSpinBox *m_box_majority;
+        QPushButton *m_btn_propagate;
+
+};
+

--- a/include/FakeSetupManager.h
+++ b/include/FakeSetupManager.h
@@ -20,6 +20,8 @@ class FakeSetupManager: public SetupManager {
         virtual bool switchHVPMTOFF(std::size_t id) override;
         virtual std::vector< std::pair<double, double> > getHVPMTValue() override;
 
+        virtual bool propagateDiscriSettings() override;
+
     private:
 
         Interface& m_interface;

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -13,9 +13,11 @@
 class ConditionManager;
 class LoggingManager;
 class HVGroup;
+class DiscriSettingsWindow;
 
 class Interface : public QWidget {
     friend class HVGroup;
+    friend class DiscriSettingsWindow;
     
     Q_OBJECT
 
@@ -35,6 +37,7 @@ class Interface : public QWidget {
     private slots:
         void startLoggingManager();
         void stopLoggingManager();
+        void showDiscriSettingsWindow();
 
     private:
       
@@ -50,4 +53,6 @@ class Interface : public QWidget {
         std::thread thread_handler;
 
         bool running;
+
+        QPushButton *m_discriTunerBtn;
 };

--- a/include/RealSetupManager.h
+++ b/include/RealSetupManager.h
@@ -4,8 +4,10 @@
 #include <vector>
 
 #include "SetupManager.h"
+
 #include "VmeUsbBridge.h"
 #include "HV.h"
+#include "Discri.h"
 
 class Interface;
 
@@ -25,10 +27,14 @@ class RealSetupManager: public SetupManager {
         virtual std::vector< std::pair<double, double> > getHVPMTValue() override;
         //virtual int getHVPMTState(size_t id) override;
 
+        // Discriminator/coincidence manager
+        virtual bool propagateDiscriSettings() override;
+
     private:
 
         UsbController m_controller;
         hv m_hvpmt;
+        discri m_discri;
         
         Interface& m_interface;
 };

--- a/include/SetupManager.h
+++ b/include/SetupManager.h
@@ -11,4 +11,6 @@ class SetupManager {
         virtual bool switchHVPMTON(std::size_t id) = 0;
         virtual bool switchHVPMTOFF(std::size_t id) = 0;
         virtual std::vector< std::pair<double, double> > getHVPMTValue() = 0;
+
+        virtual bool propagateDiscriSettings() = 0;
 };

--- a/src/ConditionManager.cpp
+++ b/src/ConditionManager.cpp
@@ -61,15 +61,16 @@ bool ConditionManager::propagateHVPMTValue(std::size_t id) {
 }
 
 bool ConditionManager::propagateHVPMTState(std::size_t id) {
-    bool result;
-    bool state = getHVPMTSetState(id);
-    if (state)
-        result = m_setup_manager->switchHVPMTON(id);
+    if (getHVPMTSetState(id))
+        return m_setup_manager->switchHVPMTON(id);
     else
-        result = m_setup_manager->switchHVPMTOFF(id);
-
-    return result;
+        return m_setup_manager->switchHVPMTOFF(id);
 }
+
+bool ConditionManager::propagateDiscriSettings() {
+    return m_setup_manager->propagateDiscriSettings();
+}
+
 
 void ConditionManager::startDaemons() {
     if( setState(State::running) ) {

--- a/src/DiscriSettingsWindow.cpp
+++ b/src/DiscriSettingsWindow.cpp
@@ -1,0 +1,138 @@
+#include <QSpinBox>
+#include <QGroupBox>
+#include <QGridLayout>
+#include <QCloseEvent>
+#include <QLabel>
+#include <QString>
+#include <QSizePolicy>
+#include <QVBoxLayout>
+
+#include "DiscriSettingsWindow.h"
+#include "Interface.h"
+#include "ConditionManager.h" 
+
+DiscriSettingsWindow::DiscriSettingsWindow(Interface& m_interface):
+    m_interface(m_interface),
+    QDialog(&m_interface) {
+        QVBoxLayout *discri_layout = new QVBoxLayout();
+        m_box = new QGroupBox("Discri Settings", this);
+        QGridLayout *discri_boxLayout = new QGridLayout();
+
+        // First display the meaning of the settings on top of it
+        int vPos_settingLabels = 0;
+
+        int hPos_threshold = 1;
+        QLabel *label_threshold = new QLabel("Threshold");
+        label_threshold->setAlignment(Qt::AlignCenter);
+        discri_boxLayout->addWidget(label_threshold, vPos_settingLabels, hPos_threshold);
+
+        int hPos_width = 2;
+        QLabel *label_width = new QLabel("Width");
+        label_width->setAlignment(Qt::AlignCenter);
+        discri_boxLayout->addWidget(label_width, vPos_settingLabels, hPos_width);
+
+        int hPos_include = 3;
+        QLabel *label_include = new QLabel("Include");
+        label_include->setAlignment(Qt::AlignCenter);
+        discri_boxLayout->addWidget(label_include, vPos_settingLabels, hPos_include);
+
+        // Display the channel settings themselves
+        int vPos_channel = 0;
+        for (int dc_id = 0; dc_id < m_interface.m_conditions->getNDiscriChannels(); dc_id++) {
+            DiscriChannel discriChannel;
+
+            vPos_channel = dc_id+1;
+
+            discriChannel.label = new QLabel("Discri channel "+QString::number(dc_id)+ " : ");
+            discri_boxLayout->addWidget(discriChannel.label, vPos_channel, 0);
+
+            discriChannel.included = new QCheckBox();
+            discriChannel.included->setStyleSheet("margin-left:50%; margin-right:50%;");
+            discriChannel.included->setChecked(m_interface.m_conditions->getDiscriChannelState(dc_id));
+            discri_boxLayout->addWidget(discriChannel.included, vPos_channel, hPos_include);
+
+            discriChannel.threshold = new QSpinBox();
+            discriChannel.threshold->setValue(m_interface.m_conditions->getDiscriChannelThreshold(dc_id));
+            discri_boxLayout->addWidget(discriChannel.threshold, vPos_channel, hPos_threshold);
+
+            discriChannel.width = new QSpinBox();
+            discriChannel.width->setMaximum(200);
+            discriChannel.width->setValue(m_interface.m_conditions->getDiscriChannelWidth(dc_id));
+            discri_boxLayout->addWidget(discriChannel.width, vPos_channel, hPos_width);
+            m_discriChannels.push_back(discriChannel);
+
+        }
+
+        // Display the number of channel required for a coincidence 
+
+        int majorityPosition = vPos_channel + 1;
+        QLabel *globalSettingsLabel = new QLabel("Global settings : ");
+        discri_boxLayout->addWidget(globalSettingsLabel, majorityPosition+1, 0);
+
+        QLabel *label_majority = new QLabel("Majority");
+        discri_boxLayout->addWidget(label_majority, majorityPosition, 1);
+        m_box_majority = new QSpinBox();
+        m_box_majority->setRange(0, m_interface.m_conditions->getNDiscriChannels());
+        m_box_majority->setWrapping(1);
+        m_box_majority->setValue(m_interface.m_conditions->getChannelsMajority());
+        m_box_majority->setAlignment(Qt::AlignCenter);
+        discri_boxLayout->addWidget(m_box_majority, majorityPosition+1, 1);
+
+        m_box->setLayout(discri_boxLayout);
+        discri_layout->addWidget(m_box);
+
+        // Button to propagate the settings
+        m_btn_propagate = new QPushButton("Propagate");
+        connect(m_btn_propagate, &QPushButton::clicked, this, &DiscriSettingsWindow::propagate);
+        // FIXME log discri settings into the condition log
+        connect(m_btn_propagate, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
+        discri_layout->addWidget(m_btn_propagate);
+
+        setLayout(discri_layout);
+        //this->adjustSize();
+    }
+
+// Ensure that the proper actions are taken when clicking the exit button
+// i.e. re-enabling the main window button opening this dialog box
+void DiscriSettingsWindow::closeEvent(QCloseEvent *event) {
+    m_interface.m_discriTunerBtn->setDisabled(0);
+    m_interface.m_discriTunerBtn->setText("Discri Settings");
+    QDialog::reject();
+}
+
+// Propagate the setting to the condition manager and to the setup
+void DiscriSettingsWindow::propagate() {
+    // Majority
+    m_interface.m_conditions->setChannelsMajority(m_box_majority->value());
+    for (int dc_id = 0; dc_id < m_interface.m_conditions->getNDiscriChannels(); dc_id++) {
+        // Include channel or not
+        m_interface.m_conditions->setDiscriChannelState(dc_id, m_discriChannels.at(dc_id).included->isChecked());
+        // Width
+        m_interface.m_conditions->setDiscriChannelWidth(dc_id, m_discriChannels.at(dc_id).width->value());
+        // Threshold
+        m_interface.m_conditions->setDiscriChannelThreshold(dc_id, m_discriChannels.at(dc_id).threshold->value());
+    }
+    // ask condition manager to propagate the settings to the setup
+    m_interface.m_conditions->propagateDiscriSettings();
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/DiscriSettingsWindow.cpp
+++ b/src/DiscriSettingsWindow.cpp
@@ -86,6 +86,7 @@ DiscriSettingsWindow::DiscriSettingsWindow(Interface& m_interface):
         connect(m_btn_propagate, &QPushButton::clicked, this, &DiscriSettingsWindow::propagate);
         // FIXME log discri settings into the condition log
         connect(m_btn_propagate, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
+        connect(m_btn_propagate, &QPushButton::clicked, [&](){ QCloseEvent *event = new QCloseEvent(); this->closeEvent(event); });
         discri_layout->addWidget(m_btn_propagate);
 
         setLayout(discri_layout);
@@ -115,24 +116,3 @@ void DiscriSettingsWindow::propagate() {
     // ask condition manager to propagate the settings to the setup
     m_interface.m_conditions->propagateDiscriSettings();
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/FakeSetupManager.cpp
+++ b/src/FakeSetupManager.cpp
@@ -27,3 +27,7 @@ std::vector< std::pair<double, double> > FakeSetupManager::getHVPMTValue() {
     }
     return hv_values;
 }
+
+bool FakeSetupManager::propagateDiscriSettings() {
+    return true;
+}

--- a/src/HVGroup.cpp
+++ b/src/HVGroup.cpp
@@ -55,7 +55,6 @@ HVGroup::HVGroup(Interface& m_interface):
             hventry.sb_set_value = new QSpinBox();
             hventry.sb_set_value->setRange(0, 2000);
             hventry.sb_set_value->setWrapping(1);
-            hventry.sb_set_value->setSingleStep(1);
             hventry.sb_set_value->setValue(setHVValue);
             
             hventry.setValue_label = new QLabel(QString::number(hventry.sb_set_value->value()));

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -11,10 +11,12 @@
 #include "LoggingManager.h"
 #include "ConditionManager.h"
 #include "HVGroup.h"
+#include "DiscriSettingsWindow.h"
 
 Interface::Interface(QWidget *parent): 
     QWidget(parent),
     m_conditions(new ConditionManager(*this)),
+    m_discriTunerBtn(new QPushButton("Discriminator Settings")),
     running(false) {
 
         std::cout << "Creating Interface. Qt version: " << qVersion() << "." << std::endl;
@@ -25,22 +27,27 @@ Interface::Interface(QWidget *parent):
         
         QPushButton *startBtn = new QPushButton("Start");
         QPushButton *stopBtn = new QPushButton("Stop");
-        QPushButton *quit = new QPushButton("Quit");
         
         m_hv_group = new HVGroup(*this);
 
         run_layout->addWidget(startBtn);
         run_layout->addWidget(stopBtn);
-        run_layout->addWidget(quit);
+        //run_layout->addWidget(m_discriTunerBtn);
         run_box->setLayout(run_layout);
+        
+        QPushButton *quit = new QPushButton("Quit");
 
         master_grid->addWidget(run_box, 0, 0);
         master_grid->addWidget(m_hv_group, 0, 1);
+        // FIXME position and button dispaching 
+        master_grid->addWidget(m_discriTunerBtn, 1, 0);
+        master_grid->addWidget(quit, 2, 0);
 
         setLayout(master_grid);
 
         connect(startBtn, &QPushButton::clicked, this, &Interface::startLoggingManager);
         connect(stopBtn, &QPushButton::clicked, this, &Interface::stopLoggingManager);
+        connect(m_discriTunerBtn, &QPushButton::clicked, this, &Interface::showDiscriSettingsWindow);
         connect(quit, &QPushButton::clicked, this, &Interface::stopLoggingManager);
         connect(quit, &QPushButton::clicked, qApp, &QApplication::quit);
 
@@ -89,4 +96,15 @@ void Interface::stopLoggingManager() {
     m_hv_group->setNotRunning();
 
     running = false;
+}
+
+// When clicking the "DiscriSetting button", open a pop up window
+// and disable the button to prevent opening dozens of windows
+void Interface::showDiscriSettingsWindow() {
+    //this->hide();
+    DiscriSettingsWindow *discriSettingsWindow = new DiscriSettingsWindow(*this);
+    discriSettingsWindow->setWindowTitle("Discriminator Settings Dialog Box");
+    discriSettingsWindow->show();
+    m_discriTunerBtn->setDisabled(1);
+    m_discriTunerBtn->setText("Discriminator Settings (already open)");
 }


### PR DESCRIPTION
First round for discriminator settings : 
- Clicking on the "Discri setting" button will open a pop-up dialog window
- Button is disabled while the pop up window is opened (avoid opening many windows)
- Button re-enabled when quitting the window
- The pop-up window contains the values we may want to change and a button "Propagate"
- Settings are propagating all at ones. We do not expect to often change them and this avoid writing many functions in the SetupManagers family
- Displayed values correspond to the default one if this is the first time you open the window. If not, they correspond to the values set when last time clicking "propagate"
