### PR TITLE
Update logger, add run number

### DIFF
--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -119,9 +119,16 @@ class ConditionManager {
          * Check if transition from `state_from` to `state_to` is allowed
          */
         static bool checkTransition(ConditionManager::State state_from, ConditionManager::State state_to);
-        
+
+        /* 
+         * Get locks. The locks are NOT locked in getters/setters below, because we assume users
+         * will take care of that when they call them. 
+         * Trying to lock a mutex in a getter/setter while the same lock was locked before by the
+         * user would result in freezing the program.
+         */
         std::mutex& getHVLock() { return m_hv_mtx; }
         std::mutex& getTDCLock() { return m_tdc_mtx; }
+        std::mutex& getDiscriLock() { return m_discri_mtx; }
 
         /*
          * Define/retrieve/propagate the PMT HV conditions
@@ -138,6 +145,9 @@ class ConditionManager {
         //int getHVPMTReadState(std::size_t id) const { return m_hvpmt.at(id).readState; }
         std::size_t getNHVPMT() const { return m_hvpmt.size(); }
 
+        /*
+         * Define/retrieve/propagate the Discriminator conditions
+         */
         void setDiscriChannelState(std::size_t id, bool state) { m_discriChannels.at(id).included = state; }
         bool getDiscriChannelState(std::size_t id) const { return m_discriChannels.at(id).included; }
         void setDiscriChannelThreshold(std::size_t id, int threshold) { m_discriChannels.at(id).threshold = threshold; }
@@ -165,6 +175,7 @@ class ConditionManager {
     private:
 
         std::mutex m_hv_mtx;
+        std::mutex m_discri_mtx;
         std::mutex m_tdc_mtx;
 
         Interface& m_interface;

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -6,6 +6,7 @@
 #include <QLabel>
 #include <QGridLayout>
 #include <QTimer>
+#include <QSpinBox>
 
 #include <thread>
 #include <memory>
@@ -54,5 +55,7 @@ class Interface : public QWidget {
 
         bool running;
 
+        QSpinBox *m_runNumberSpin;
+        QLabel *m_runNumberLabel;
         QPushButton *m_discriTunerBtn;
 };

--- a/include/LoggingManager.h
+++ b/include/LoggingManager.h
@@ -101,7 +101,7 @@ class LoggingManager {
       
       using m_clock = std::chrono::system_clock;
 
-      LoggingManager(Interface& m_interface, uint32_t m_continuous_log_time = 1000);
+      LoggingManager(Interface& m_interface, uint32_t run_number, uint32_t m_continuous_log_time = 1000);
       ~LoggingManager() {};
 
       void run();
@@ -109,6 +109,11 @@ class LoggingManager {
       
       // Public: if interface changes something during a run, we have to update
       void updateConditionManagerLog(bool first_time = false, m_clock::time_point log_time = m_clock::now());
+
+      /* Static: to check if creating a LoggingManager with a certain run number would overwrite existing log files
+       * Return: true if log files already exist
+       */
+      static bool checkRunNumber(uint32_t number);
   
   private:
         
@@ -124,6 +129,7 @@ class LoggingManager {
       std::atomic<bool> is_running;
 
       uint32_t m_continuous_log_time;
+      uint32_t m_run_number;
       std::shared_ptr<CSV> m_continuous_log;
 
       Json::Value m_condition_json_root;

--- a/include/LoggingManager.h
+++ b/include/LoggingManager.h
@@ -24,7 +24,7 @@ class CSV {
         
         CSV(std::string fileName): m_frozen(false) {
             m_file.open(fileName);
-            if(!m_file.is_open())
+            if (!m_file.is_open())
                 throw std::ios_base::failure("Could not open file " + fileName);
         }
         ~CSV() { m_file.close(); }

--- a/src/DiscriSettingsWindow.cpp
+++ b/src/DiscriSettingsWindow.cpp
@@ -36,6 +36,8 @@ DiscriSettingsWindow::DiscriSettingsWindow(Interface& m_interface):
         label_include->setAlignment(Qt::AlignCenter);
         discri_boxLayout->addWidget(label_include, vPos_settingLabels, hPos_include);
 
+        std::lock_guard<std::mutex> m_lock(m_interface.m_conditions->getDiscriLock());
+        
         // Display the channel settings themselves
         int vPos_channel = 0;
         for (int dc_id = 0; dc_id < m_interface.m_conditions->getNDiscriChannels(); dc_id++) {
@@ -43,7 +45,7 @@ DiscriSettingsWindow::DiscriSettingsWindow(Interface& m_interface):
 
             vPos_channel = dc_id+1;
 
-            discriChannel.label = new QLabel("Discri channel "+QString::number(dc_id)+ " : ");
+            discriChannel.label = new QLabel("Discri channel " + QString::number(dc_id) + " : ");
             discri_boxLayout->addWidget(discriChannel.label, vPos_channel, 0);
 
             discriChannel.included = new QCheckBox();
@@ -101,6 +103,9 @@ void DiscriSettingsWindow::closeEvent(QCloseEvent *event) {
 
 // Propagate the setting to the condition manager and to the setup
 void DiscriSettingsWindow::propagate() {
+        
+    std::lock_guard<std::mutex> m_lock(m_interface.m_conditions->getDiscriLock());
+    
     // Majority
     m_interface.m_conditions->setChannelsMajority(m_box_majority->value());
     

--- a/src/DiscriSettingsWindow.cpp
+++ b/src/DiscriSettingsWindow.cpp
@@ -84,13 +84,11 @@ DiscriSettingsWindow::DiscriSettingsWindow(Interface& m_interface):
         // Button to propagate the settings
         m_btn_propagate = new QPushButton("Propagate");
         connect(m_btn_propagate, &QPushButton::clicked, this, &DiscriSettingsWindow::propagate);
-        // FIXME log discri settings into the condition log
         connect(m_btn_propagate, &QPushButton::clicked, &m_interface, &Interface::updateConditionLog);
         connect(m_btn_propagate, &QPushButton::clicked, [&](){ QCloseEvent *event = new QCloseEvent(); this->closeEvent(event); });
         discri_layout->addWidget(m_btn_propagate);
 
         setLayout(discri_layout);
-        //this->adjustSize();
     }
 
 // Ensure that the proper actions are taken when clicking the exit button
@@ -105,6 +103,7 @@ void DiscriSettingsWindow::closeEvent(QCloseEvent *event) {
 void DiscriSettingsWindow::propagate() {
     // Majority
     m_interface.m_conditions->setChannelsMajority(m_box_majority->value());
+    
     for (int dc_id = 0; dc_id < m_interface.m_conditions->getNDiscriChannels(); dc_id++) {
         // Include channel or not
         m_interface.m_conditions->setDiscriChannelState(dc_id, m_discriChannels.at(dc_id).included->isChecked());
@@ -113,6 +112,7 @@ void DiscriSettingsWindow::propagate() {
         // Threshold
         m_interface.m_conditions->setDiscriChannelThreshold(dc_id, m_discriChannels.at(dc_id).threshold->value());
     }
+    
     // ask condition manager to propagate the settings to the setup
     m_interface.m_conditions->propagateDiscriSettings();
 }

--- a/src/HVGroup.cpp
+++ b/src/HVGroup.cpp
@@ -37,6 +37,8 @@ HVGroup::HVGroup(Interface& m_interface):
         m_layout->addWidget(toplabel_set_state, 0, position_set_state);
 
         //m_layout->addWidget(toplabel_read_state, 0, 4);
+    
+        std::lock_guard<std::mutex> m_lock(m_interface.m_conditions->getHVLock());
 
         for (int hv_id = 0; hv_id < m_interface.m_conditions->getNHVPMT(); hv_id++) {
 

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -4,8 +4,13 @@
 #include <QLabel>
 #include <QGridLayout>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QGroupBox>
 #include <QTimer>
+#include <QSpinBox>
+#include <QMessageBox>
+
+#include <limits>
 
 #include "Interface.h"
 #include "LoggingManager.h"
@@ -20,31 +25,46 @@ Interface::Interface(QWidget *parent):
     running(false) {
 
         std::cout << "Creating Interface. Qt version: " << qVersion() << "." << std::endl;
-        QGridLayout *master_grid = new QGridLayout();
 
+        /* ----- Run control box ----- */
         QGroupBox *run_box = new QGroupBox("Run control");
         QVBoxLayout *run_layout = new QVBoxLayout();
+       
+        QHBoxLayout *runNumber_layout = new QHBoxLayout();
+        QLabel *runLabel = new QLabel("Run number: ");
+        runLabel->setAlignment(Qt::AlignCenter);
+        m_runNumberLabel = new QLabel();
+        m_runNumberLabel->setAlignment(Qt::AlignCenter);
+        m_runNumberSpin = new QSpinBox();
+        m_runNumberSpin->setRange(0, std::numeric_limits<int>::max());
+        runNumber_layout->addWidget(runLabel);
+        runNumber_layout->addWidget(m_runNumberLabel);
+        runNumber_layout->addWidget(m_runNumberSpin);
         
         QPushButton *startBtn = new QPushButton("Start");
         QPushButton *stopBtn = new QPushButton("Stop");
         
-        m_hv_group = new HVGroup(*this);
-
         run_layout->addWidget(startBtn);
         run_layout->addWidget(stopBtn);
-        //run_layout->addWidget(m_discriTunerBtn);
+        run_layout->addLayout(runNumber_layout);
         run_box->setLayout(run_layout);
         
+        /* ----- HV control box ----- */
+        m_hv_group = new HVGroup(*this);
+        
+        /* ----- Master grid ----- */
         QPushButton *quit = new QPushButton("Quit");
 
+        QGridLayout *master_grid = new QGridLayout();
+        
         master_grid->addWidget(run_box, 0, 0);
         master_grid->addWidget(m_hv_group, 0, 1);
-        // FIXME position and button dispaching 
         master_grid->addWidget(m_discriTunerBtn, 1, 0);
         master_grid->addWidget(quit, 2, 0);
 
         setLayout(master_grid);
 
+        /* ----- Connect signals ----- */
         connect(startBtn, &QPushButton::clicked, this, &Interface::startLoggingManager);
         connect(stopBtn, &QPushButton::clicked, this, &Interface::stopLoggingManager);
         connect(m_discriTunerBtn, &QPushButton::clicked, this, &Interface::showDiscriSettingsWindow);
@@ -75,10 +95,23 @@ void Interface::startLoggingManager() {
     if(m_logging_manager.get())
         return;
 
-    m_logging_manager = std::make_shared<LoggingManager>(*this);
+    uint32_t run_number = m_runNumberSpin->value();
+
+    // Check if we can start with the given run number
+    if (LoggingManager::checkRunNumber(run_number)) {
+        QMessageBox msgBox(QMessageBox::Warning, "Warning", "Warning: log files for run number " + QString::number(run_number) + " already exist. Do you want to go on and overwrite them?", QMessageBox::Ok | QMessageBox::Cancel);
+        msgBox.setDefaultButton(QMessageBox::Cancel);
+        if (msgBox.exec() == QMessageBox::Cancel)
+            return;
+    }
+
+    m_logging_manager = std::make_shared<LoggingManager>(*this, run_number);
     thread_handler = std::thread(&LoggingManager::run, std::ref(*m_logging_manager));
 
     m_hv_group->setRunning();
+    m_runNumberSpin->hide();
+    m_runNumberLabel->setText(QString::number(run_number));
+    m_runNumberLabel->show();
 
     running = true;
 }
@@ -94,6 +127,9 @@ void Interface::stopLoggingManager() {
     notifyUpdate();
 
     m_hv_group->setNotRunning();
+    m_runNumberLabel->hide();
+    m_runNumberSpin->setValue(m_runNumberSpin->value() + 1);
+    m_runNumberSpin->show();
 
     running = false;
 }

--- a/src/LoggingManager.cpp
+++ b/src/LoggingManager.cpp
@@ -101,17 +101,35 @@ void LoggingManager::updateConditionManagerLog(bool first_time, m_clock::time_po
     
     Json::Value this_condition;
     Json::Value hv_values;
+    Json::Value discri_values;
 
-    // Lock the conditions manager to read all the values at once
-    std::lock_guard<std::mutex> hv_lock(m_conditions.getHVLock());
+    { // Lock the HV using the conditions manager to read all the values at once
+        std::lock_guard<std::mutex> hv_lock(m_conditions.getHVLock());
+        
+        for (size_t id = 0; id < m_conditions.getNHVPMT(); id++) {
+            Json::Value this_value;
+            this_value["setValue"] = m_conditions.getHVPMTSetValue(id);
+            this_value["readValue"] = m_conditions.getHVPMTReadValue(id);
+            this_value["setState"] = m_conditions.getHVPMTSetState(id);
+            hv_values[ "hv_" + std::to_string(id) ] = this_value;
+        }
+    } // End HV lock 
     
-    for (size_t id = 0; id < m_conditions.getNHVPMT(); id++) {
-        hv_values[ "hv_" + std::to_string(id) + "_setValue" ] = m_conditions.getHVPMTSetValue(id);
-        hv_values[ "hv_" + std::to_string(id) + "_readValue" ] = m_conditions.getHVPMTReadValue(id);
-        hv_values[ "hv_" + std::to_string(id) + "_setState" ] = m_conditions.getHVPMTSetState(id);
-    }
+    { // Lock the Discriminator using the conditions manager to read all the values at once
+        std::lock_guard<std::mutex> discri_lock(m_conditions.getDiscriLock());
+
+        for (size_t id = 0; id < m_conditions.getNDiscriChannels(); id++) {
+            Json::Value this_value;
+            this_value["included"] = m_conditions.getDiscriChannelState(id);
+            this_value["threshold"] = m_conditions.getDiscriChannelThreshold(id);
+            this_value["width"] = m_conditions.getDiscriChannelWidth(id);
+            discri_values[ "discri_" + std::to_string(id) ] = this_value;
+            discri_values[ "discri_majority" ] = m_conditions.getChannelsMajority();
+        }
+    } // End Discriminator lock 
     
     this_condition["hv_values"] = hv_values;
+    this_condition["discri_values"] = discri_values;
     this_condition["time"] = timeToJson<m_clock>(log_time); 
     
     m_condition_json_list.append(this_condition);


### PR DESCRIPTION
Update logger to log discriminator settings into conditions log.

Add spin box to choose a run number. The number is logged in the conditions log, and is used to define the log file names. When the logger is running, the spin box is replaced by a label. When the run is stopped, the number in the spin box is increased by 1. If log files with the run number already exist, confirmation is asked to overwrite them.

Here's what it looks like:
![temp](https://cloud.githubusercontent.com/assets/8058274/17106882/477efae0-528d-11e6-88c6-f6d9fa4565a6.png)
