### PR TITLE
Trigger Control

### DIFF
--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -37,7 +37,9 @@ class ConditionManager {
                     { false, 5, 200 },
                     { false, 5, 200 }
                     }),
-            m_channelsMajority(3)
+            m_channelsMajority(3),
+            m_triggerChannel(1),
+            m_triggerRandomFrequency(0)
         {
             std::cout << "Checking if the PC is connected to board..." << std::endl;
             UsbController *dummy_controller = new UsbController(DEBUG);
@@ -145,6 +147,14 @@ class ConditionManager {
         //int getHVPMTReadState(std::size_t id) const { return m_hvpmt.at(id).readState; }
         std::size_t getNHVPMT() const { return m_hvpmt.size(); }
 
+        // Trigger control: channel 1 --> physics,  channel 5 --> random
+        void setTriggerChannel(int channel) { m_triggerChannel = channel; }
+        int getTriggerChannel() { return m_triggerChannel; }
+        void setTriggerRandomFrequency(int frequency) { m_triggerRandomFrequency = frequency; }
+        int getTriggerRandomFrequency() { return m_triggerRandomFrequency; }
+        void startTrigger();
+        void stopTrigger();
+
         /*
          * Define/retrieve/propagate the Discriminator conditions
          */
@@ -187,6 +197,9 @@ class ConditionManager {
         std::vector<HVPMT> m_hvpmt;
         std::vector<DiscriChannel> m_discriChannels;
         int m_channelsMajority;
+
+        int m_triggerChannel;
+        int m_triggerRandomFrequency;
         
         std::shared_ptr<SetupManager> m_setup_manager;
 };

--- a/include/FakeSetupManager.h
+++ b/include/FakeSetupManager.h
@@ -20,6 +20,8 @@ class FakeSetupManager: public SetupManager {
         virtual bool switchHVPMTOFF(std::size_t id) override;
         virtual std::vector< std::pair<double, double> > getHVPMTValue() override;
 
+        virtual void setTrigger(int channel, int randomFrequency) override;
+
         virtual bool propagateDiscriSettings() override;
 
     private:

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -36,8 +36,8 @@ class Interface : public QWidget {
         void notifyUpdate();
 
     private slots:
-        void startLoggingManager();
-        void stopLoggingManager();
+        void startRun();
+        void stopRun();
         void showDiscriSettingsWindow();
 
     private:
@@ -58,4 +58,7 @@ class Interface : public QWidget {
         QSpinBox *m_runNumberSpin;
         QLabel *m_runNumberLabel;
         QPushButton *m_discriTunerBtn;
+
+        QSpinBox *m_triggerChannel_box;
+        QSpinBox *m_triggerRandom_box;
 };

--- a/include/RealSetupManager.h
+++ b/include/RealSetupManager.h
@@ -8,6 +8,7 @@
 #include "VmeUsbBridge.h"
 #include "HV.h"
 #include "Discri.h"
+#include "TTCvi.h"
 
 class Interface;
 
@@ -27,6 +28,9 @@ class RealSetupManager: public SetupManager {
         virtual std::vector< std::pair<double, double> > getHVPMTValue() override;
         //virtual int getHVPMTState(size_t id) override;
 
+        // Trigger control : channel 1 --> physics trigger, channel 5 --> random triggers
+        virtual void setTrigger(int channel, int randomFrequency) override;
+
         // Discriminator/coincidence manager
         virtual bool propagateDiscriSettings() override;
 
@@ -35,6 +39,7 @@ class RealSetupManager: public SetupManager {
         UsbController m_controller;
         hv m_hvpmt;
         discri m_discri;
+        ttcVi m_TTC;
         
         Interface& m_interface;
 };

--- a/include/SetupManager.h
+++ b/include/SetupManager.h
@@ -12,5 +12,7 @@ class SetupManager {
         virtual bool switchHVPMTOFF(std::size_t id) = 0;
         virtual std::vector< std::pair<double, double> > getHVPMTValue() = 0;
 
+        virtual void setTrigger(int channel, int randomFrequency) = 0;
+
         virtual bool propagateDiscriSettings() = 0;
 };

--- a/src/ConditionManager.cpp
+++ b/src/ConditionManager.cpp
@@ -71,6 +71,13 @@ bool ConditionManager::propagateDiscriSettings() {
     return m_setup_manager->propagateDiscriSettings();
 }
 
+void ConditionManager::startTrigger() {
+    m_setup_manager->setTrigger(m_triggerChannel, m_triggerRandomFrequency);
+}
+
+void ConditionManager::stopTrigger() {
+    m_setup_manager->setTrigger(7, 0); // Channel 7 means disabled...
+}
 
 void ConditionManager::startDaemons() {
     if( setState(State::running) ) {

--- a/src/FakeSetupManager.cpp
+++ b/src/FakeSetupManager.cpp
@@ -28,6 +28,10 @@ std::vector< std::pair<double, double> > FakeSetupManager::getHVPMTValue() {
     return hv_values;
 }
 
+void FakeSetupManager::setTrigger(int channel, int frequency) {
+    return;
+}
+
 bool FakeSetupManager::propagateDiscriSettings() {
     return true;
 }

--- a/src/RealSetupManager.cpp
+++ b/src/RealSetupManager.cpp
@@ -4,6 +4,7 @@
 #include "VmeUsbBridge.h"
 #include "HV.h"
 #include "Discri.h"
+#include "TTCvi.h"
 
 #include "RealSetupManager.h"
 #include "Interface.h"
@@ -13,7 +14,8 @@ RealSetupManager::RealSetupManager(Interface& m_interface):
     m_interface(m_interface),
     m_controller(UsbController(NORMAL)),
     m_hvpmt(hv(&m_controller, 0xF0000, 2)),
-    m_discri(discri(&m_controller))
+    m_discri(discri(&m_controller)),
+    m_TTC(ttcVi(&m_controller))
     { }
 
 RealSetupManager::~RealSetupManager() {
@@ -68,6 +70,23 @@ bool RealSetupManager::propagateDiscriSettings() {
 
     }
     return succeeded_majority && succeeded_discriSettings;
+}
+
+void RealSetupManager::setTrigger(int channel, int randomFrequency) {
+    m_TTC.resetCounter();
+    if (channel == 7){
+        std::cout << "Disabling trigger..." << std::endl;
+        m_TTC.changeChannel(channel);
+        return;
+    }
+    else {
+        std::cout << "Setting trigger to channel " << channel << "..." << std::endl;
+    }
+    if (channel == 5 || channel == -1){
+        std::cout << "Trigger in random mode with frequency mode " << randomFrequency << "..." << std::endl;
+        m_TTC.changeRandomFrequency(randomFrequency);
+    }
+    m_TTC.changeChannel(channel);
 }
 
 


### PR DESCRIPTION
Add trigger settings to the run control panel. 
- Start and stop trigger when clicking on start/stop button
- Actions are taken in the start(stop)LoggingManager which has been renamed to start(stop)Run
- Possibility to chose the trigger mode (physics1, physics2, random...)
- Possibility to choose the random rate
- When quitting the window, trigger is automatically disabled

Note : provided that an expert will always be present when running, we decided to leave the "cryptic" channel and frequency modes described [here](http://delcourt.web.cern.ch/delcourt/cosmictrigger/doc/classttcVi.html#a5178795a2fc5cbae267c48b5b8c03f66). 

What is missing is an integration with the state machine, where we would like eventually to add the following protection: switch trigger off and freeze the UI settings when going into configure state. 
