### PR TITLE
Add some useful argumens to main

### DIFF
--- a/include/ConditionManager.h
+++ b/include/ConditionManager.h
@@ -24,7 +24,7 @@ class ConditionManager {
     
     public:
 
-        ConditionManager(Interface& m_interface);
+        ConditionManager(Interface& m_interface, bool use_fake_setup);
         ~ConditionManager();
 
         class daemon_state_error: public std::runtime_error {

--- a/include/Interface.h
+++ b/include/Interface.h
@@ -12,6 +12,8 @@
 #include <memory>
 #include <atomic>
 
+#include "Utils.h"
+
 class ConditionManager;
 class LoggingManager;
 class HVGroup;
@@ -26,7 +28,7 @@ class Interface : public QWidget {
     Q_OBJECT
 
     public:
-        Interface(QWidget *parent = 0);
+        Interface(Arguments m_args, QWidget* parent = 0);
 
         virtual ~Interface() {}
 
@@ -88,6 +90,8 @@ class Interface : public QWidget {
         void showDiscriSettingsWindow();
 
     private:
+
+        Arguments m_args;
       
         void setCounter(int i);
 

--- a/include/LoggingManager.h
+++ b/include/LoggingManager.h
@@ -108,7 +108,7 @@ class LoggingManager {
       
       using m_clock = std::chrono::system_clock;
 
-      LoggingManager(Interface& m_interface, std::uint32_t run_number, std::uint32_t m_continuous_log_time = 1000);
+      LoggingManager(Interface& m_interface, std::uint32_t run_number, std::string log_path = "./", std::uint32_t m_continuous_log_time = 1000);
       ~LoggingManager();
 
       void run();
@@ -124,7 +124,7 @@ class LoggingManager {
       /* Static: to check if creating a LoggingManager with a certain run number would overwrite existing log files
        * Return: true if log files already exist
        */
-      static bool checkRunNumber(std::uint32_t number);
+      static bool checkRunNumber(std::uint32_t number, std::string log_path = "./");
   
   private:
         
@@ -143,6 +143,7 @@ class LoggingManager {
       ConditionManager& m_conditions;
       std::atomic<bool> is_running;
 
+      std::string m_log_path;
       std::uint32_t m_continuous_log_time;
       std::uint32_t m_run_number;
       std::shared_ptr<CSV> m_continuous_log;

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -6,9 +6,13 @@
 #include <cstdint>
 #include <list>
 #include <chrono>
+#include <iostream>
 
 #include <json/json.h>
 
+/*
+ * Numbers for the scaler channels
+ */
 enum class ScalerChannel {
     PM0 = 1,
     PM1,
@@ -16,6 +20,42 @@ enum class ScalerChannel {
     VME,
     TTC,
     Ileak 
+};
+
+/*
+ * Small helper class to handle arguments for main
+ * Everything is static...
+ */
+class Arguments {
+    public:
+        Arguments(int argc, char **argv):
+            log_path("./"),
+            use_fake_setup(false)
+        {
+            for (std::size_t i = 1; i < argc; i++)
+                parseArgument(argv[i]);
+        }
+
+        std::string log_path;
+        bool use_fake_setup;
+
+    private:
+        void parseArgument(std::string arg) {
+            if (arg == "-f" || arg == "--fake") {
+                std::cout << "Will use fake setup no matter what." << std::endl;
+                use_fake_setup = true;
+                return;
+            } else if (arg == "-h" || arg == "--help") {
+                std::cout << "--- Slow control interface for test beam at Louvain ---\n\n";
+                std::cout << "List of available options:\n";
+                std::cout << " - '-f'/'--fake': Use fake setup even if real setup is connected (default false)\n";
+                std::cout << " - '-h'/'--help': Display this help\n";
+                std::cout << " - Unnamed argument: specify path to directory where log files will be stored (fault to current directory)\n\n";
+            } else {
+                std::cout << "Will write log files to " << arg << std::endl;
+                log_path = arg;
+            }
+        }
 };
 
 

--- a/src/ConditionManager.cpp
+++ b/src/ConditionManager.cpp
@@ -32,11 +32,11 @@ ConditionManager::ConditionManager(Interface& m_interface, bool use_fake_setup):
     m_discriChannels({
             { true, 5, 200 },
             { true, 5, 200 },
-            { true, 5, 200 },
+            { false, 5, 200 },
             { false, 5, 200 },
             { false, 5, 200 }
             }),
-    m_channelsMajority(3),
+    m_channelsMajority(2),
     m_triggerChannel(1),
     m_triggerRandomFrequency(0),
     m_TDC_offsetMinimum(5),

--- a/src/ConditionManager.cpp
+++ b/src/ConditionManager.cpp
@@ -21,7 +21,7 @@ const std::map<ScalerChannel, std::pair<std::string, double>> ConditionManager::
 };
 
 
-ConditionManager::ConditionManager(Interface& m_interface):
+ConditionManager::ConditionManager(Interface& m_interface, bool use_fake_setup):
     m_interface(m_interface),
     m_HV_daemon_running(false),
     m_TDC_daemon_running(false),
@@ -51,11 +51,14 @@ ConditionManager::ConditionManager(Interface& m_interface):
     if (m_TDC_evtBuffer_flushSize > 1000)
         m_TDC_evtBuffer_flushSize = 1000;
 
-    std::cout << "Checking if the PC is connected to board..." << std::endl;
-    UsbController *dummy_controller = new UsbController(DEBUG);
-    bool canTalkToBoards = (dummy_controller->getStatus() == 0);
-    std::cout << "Deleting dummy USB controller..." << std::endl;
-    delete dummy_controller;
+    bool canTalkToBoards = false;
+    if (!use_fake_setup) {
+        std::cout << "Checking if the PC is connected to board..." << std::endl;
+        UsbController *dummy_controller = new UsbController(DEBUG);
+        canTalkToBoards = (dummy_controller->getStatus() == 0);
+        std::cout << "Deleting dummy USB controller..." << std::endl;
+        delete dummy_controller;
+    }
     if (canTalkToBoards) {
         std::cout << "You are on 'the' machine connected to the boards and can take action on them." << std::endl;
         m_setup_manager = std::make_shared<RealSetupManager>(m_interface);

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -64,9 +64,10 @@ bool Interface::setState(Interface::State state) {
     return true;
 }
 
-Interface::Interface(QWidget *parent): 
+Interface::Interface(Arguments m_args, QWidget *parent): 
     QWidget(parent),
-    m_conditions(new ConditionManager(*this)),
+    m_args(m_args),
+    m_conditions(new ConditionManager(*this, m_args.use_fake_setup)),
     m_state(State::idle)
     {
 
@@ -186,7 +187,7 @@ void Interface::configureRun() {
         m_conditions->propagateDiscriSettings();
     }
 
-    m_logging_manager = std::make_shared<LoggingManager>(*this, run_number);
+    m_logging_manager = std::make_shared<LoggingManager>(*this, run_number, m_args.log_path);
     
     m_ttc_tdc_group->atConfigureRun();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,13 @@
 #include <QApplication>
 
 #include "Interface.h"
+#include "Utils.h"
 
 int main(int argc, char **argv) {
     QApplication my_app(argc, argv);
  
-    Interface interface;
+    Arguments m_args(argc, argv);
+    Interface interface(m_args);
 
     interface.show();
 


### PR DESCRIPTION
Quick and dirty addition to pass arguments to the program. For instance, `./SlowControlTBL -f ../logs/` will force the use of the fake setup even if the real setup is connected, and store all log files in the `../logs/` folder. Caution: the folder has to exist!